### PR TITLE
Add context and propagate settings to plugins

### DIFF
--- a/src/resqui/cli.py
+++ b/src/resqui/cli.py
@@ -17,49 +17,13 @@ import itertools
 import time
 import threading
 import importlib
-import json
 import sys
 
+from .core import Configuration, Context, Summary
 from .plugins import IndicatorPlugin
 from .api import Publisher
 from .docopt import docopt
 from .version import __version__
-
-
-class Configuration:
-    """
-    A basic wrapper for the configuration.
-    """
-
-    def __init__(self, filepath):
-        with open(filepath) as f:
-            self._cfg = json.load(f)
-
-
-class Summary:
-    """
-    Summary of the results of the checks.
-    """
-
-    def __init__(self):
-        self.checks = []
-
-    def add_indicator_result(self, indicator, checking_software, status):
-        self.checks.append(
-            {
-                "checking_software": {
-                    "name": checking_software.name,
-                    "id": checking_software.id,
-                    "version": checking_software.version,
-                },
-                "indicator": indicator,
-                "status": status,
-            }
-        )
-
-    def to_json(self, filename):
-        with open(filename, "w") as f:
-            json.dump(self.checks, f, indent=4)
 
 
 class Spinner:
@@ -120,6 +84,8 @@ def resqui():
     if github_token is not None:
         print("GitHub API token \033[92m✔\033[0m")
 
+    context = Context(github_token=github_token)
+
     print(f"Repository URL: {url}")
     print(f"Branch: {branch}")
     print("Checking indicators ...")
@@ -139,7 +105,7 @@ def resqui():
         plugin_class = getattr(plugin_module, plugin_class_name)
         plugin_method = indicator["name"]
         with Spinner():
-            plugin_instance = plugin_class()
+            plugin_instance = plugin_class(context)
             result = getattr(plugin_instance, plugin_method)(url, branch)
 
         if result:

--- a/src/resqui/core.py
+++ b/src/resqui/core.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+from dataclasses import dataclass
+from typing import Optional
+import json
+
+
+@dataclass(frozen=True)
+class Context:
+    """A basic context to hold"""
+
+    github_token: Optional[str] = None
+
+
+class Configuration:
+    """
+    A basic wrapper for the configuration.
+    """
+
+    def __init__(self, filepath):
+        with open(filepath) as f:
+            self._cfg = json.load(f)
+
+
+class Summary:
+    """
+    Summary of the results of the checks.
+    """
+
+    def __init__(self):
+        self.checks = []
+
+    def add_indicator_result(self, indicator, checking_software, status):
+        self.checks.append(
+            {
+                "checking_software": {
+                    "name": checking_software.name,
+                    "id": checking_software.id,
+                    "version": checking_software.version,
+                },
+                "indicator": indicator,
+                "status": status,
+            }
+        )
+
+    def to_json(self, filename):
+        with open(filename, "w") as f:
+            json.dump(self.checks, f, indent=4)

--- a/src/resqui/plugins.py
+++ b/src/resqui/plugins.py
@@ -131,7 +131,8 @@ class HowFairIs(IndicatorPlugin):
     id = "https://w3id.org/everse/tools/howfairis"
     indicators = ["has_license"]
 
-    def __init__(self):
+    def __init__(self, context):
+        self.context = context
         self.executor = PythonExecutor()
         self.executor.install(f"{self.python_package_name}=={self.version}")
 
@@ -155,7 +156,8 @@ class CFFConvert(IndicatorPlugin):
     id = "https://w3id.org/everse/tools/cffconvert"
     indicators = ["has_citation"]
 
-    def __init__(self):
+    def __init__(self, context):
+        self.context = context
         self.executor = PythonExecutor()
         self.executor.install(f"{self.python_package_name}=={self.version}")
 
@@ -179,7 +181,8 @@ class Gitleaks(IndicatorPlugin):
     id = "https://w3id.org/everse/tools/gitleaks"
     indicators = ["has_security_leak"]
 
-    def __init__(self):
+    def __init__(self, context):
+        self.context = context
         self.executor = DockerExecutor(self.image_url)
 
     def has_security_leak(self, url, branch):
@@ -222,7 +225,8 @@ class SuperLinter(IndicatorPlugin):
     id = "https://w3id.org/everse/tools/superlinter"
     indicators = ["has_no_linting_issues"]
 
-    def __init__(self):
+    def __init__(self, context):
+        self.context = context
         machine = platform.machine()
         pull_args = ["--platform", "linux/amd64"] if machine == "arm64" else []
         self.executor = DockerExecutor(self.image_url, pull_args=pull_args)


### PR DESCRIPTION
The `Context` class holds the global context of the CI job and currently only holds the optional GitHub API token. It is passed to indicator plugins' init.

This PR is a pre-requisite to #11 