### PR TITLE
Fix CI example job

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,4 +34,4 @@ jobs:
         run: make test
 
       - name: Run example
-        run: resqui -c example.json -t ${{ secrets.GITHUB_TOKEN }} https://github.com/ossf/scorecard
+        run: resqui -c example.json -t ${{ secrets.GITHUB_TOKEN }} https://github.com/EVERSE-ResearchSoftware/QualityPipelines

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,4 +34,4 @@ jobs:
         run: make test
 
       - name: Run example
-        run: resqui -c example.json -t ${{ secrets.GITHUB_TOKEN }} https://github.com/JuliaHEP/UnROOT.jl
+        run: resqui -c example.json -t ${{ secrets.GITHUB_TOKEN }} https://github.com/ossf/scorecard


### PR DESCRIPTION
It's a bit unclear how to overcome the `GITHUB_TOKEN` barrier for the CI. Maybe a PAT, or maybe we need a repo which has more relaxed branch access rules 😉 