### PR TITLE
Issues and PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,79 @@
+name: Bug report
+description: Report a failure in the resqui CLI, GitHub Action, configuration loading, or an indicator plugin.
+title: "bug: "
+labels:
+  - bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this form for reproducible problems in `resqui`, the composite action in `action.yml`, or a plugin under `src/resqui/plugins/`.
+  - type: dropdown
+    id: area
+    attributes:
+      label: Where does the failure happen?
+      options:
+        - resqui CLI
+        - GitHub Action (`action.yml`)
+        - Configuration file in `configurations/` or custom JSON
+        - Plugin in `src/resqui/plugins/`
+        - Python executor
+        - Docker executor
+        - Test or CI workflow
+        - Other (describe below)
+    validations:
+      required: true
+  - type: input
+    id: command
+    attributes:
+      label: Exact command or workflow step
+      description: Include the `resqui` command, `make test`, or the workflow step name that fails.
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: What did you expect to happen?
+      description: State the expected check result, output file, or workflow outcome.
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: What happened instead?
+      description: Paste the relevant traceback, stderr, or failing job log.
+      render: shell
+    validations:
+      required: true
+  - type: input
+    id: repository
+    attributes:
+      label: Repository being assessed
+      description: If the failure is not on this repository, provide the target repository URL that `resqui` checked.
+    validations:
+      required: false
+  - type: input
+    id: config
+    attributes:
+      label: Configuration file
+      description: Name the JSON file you used, for example `configurations/basic.json`, or state that you ran without `-c`.
+    validations:
+      required: true
+  - type: dropdown
+    id: environment
+    attributes:
+      label: How did you run it?
+      options:
+        - Local Python environment
+        - GitHub Actions
+        - Local Docker environment
+    validations:
+      required: true
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Quick checks
+      options:
+        - label: I ran `make test` or `python3 run_tests.py` after reproducing the problem locally.
+        - label: If this involves the composite action, I checked the workflow example in `README.md` and the inputs in `action.yml`.
+        - label: If this involves a plugin, I know which plugin or indicator name failed.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: resqui usage and configuration
+    url: https://github.com/EVERSE-ResearchSoftware/QualityPipelines/blob/main/README.md
+    about: Check the CLI options, configuration file format, output schema, and example commands before opening an issue.
+  - name: GitHub Action setup
+    url: https://github.com/EVERSE-ResearchSoftware/QualityPipelines/blob/main/README.md#github-action
+    about: Use this if your question is about wiring the action into .github/workflows/ or providing DASHVERSE_TOKEN and GITHUB_TOKEN.

--- a/.github/ISSUE_TEMPLATE/plugin_or_indicator_request.yml
+++ b/.github/ISSUE_TEMPLATE/plugin_or_indicator_request.yml
@@ -1,0 +1,65 @@
+name: Plugin or indicator request
+description: Propose a new indicator, a new plugin, or an extension to an existing plugin.
+title: "enhancement: "
+labels:
+  - enhancement
+  - plugin
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this form for additions that fit the plugin model in `src/resqui/plugins/` and the configuration format consumed by `resqui -c ...`.
+  - type: input
+    id: indicator
+    attributes:
+      label: Indicator name
+      description: Provide the method-style indicator name you expect to appear in configuration JSON, such as `has_license`.
+    validations:
+      required: true
+  - type: textarea
+    id: rationale
+    attributes:
+      label: Why does this indicator belong in resqui?
+      description: Tie it to research software quality assessment, existing EVERSE indicators, or a concrete gap in the current default configuration.
+    validations:
+      required: true
+  - type: dropdown
+    id: implementation
+    attributes:
+      label: Best implementation path
+      options:
+        - Extend an existing plugin in `src/resqui/plugins/`
+        - Add a new Python-based plugin
+        - Add a new Docker-based plugin
+        - Not sure yet
+    validations:
+      required: true
+  - type: textarea
+    id: evidence
+    attributes:
+      label: Expected result and evidence
+      description: Describe the expected `CheckResult.output`, success condition, and the evidence text the plugin should report.
+    validations:
+      required: true
+  - type: textarea
+    id: external_tool
+    attributes:
+      label: External tool or package
+      description: Name the Python package, container image, API, or specification this would rely on, including version constraints if they matter.
+    validations:
+      required: false
+  - type: textarea
+    id: config_example
+    attributes:
+      label: Example configuration entry
+      description: Show the JSON entry you would expect to add under `indicators`, including `name`, `plugin`, and `@id` when known.
+      render: json
+    validations:
+      required: true
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Before submitting
+      options:
+        - label: I checked the existing plugins in `src/resqui/plugins/` and this is not already covered.
+        - label: I checked the shipped JSON configs in `configurations/` and can explain where this request fits.

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -1,0 +1,52 @@
+name: Usage question
+description: Ask about running resqui, configuring indicators, or integrating the GitHub Action.
+title: "question: "
+labels:
+  - question
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this form for questions about command usage, configuration JSON, tokens, output JSON, or the GitHub Action wiring shown in `README.md`.
+  - type: dropdown
+    id: topic
+    attributes:
+      label: What do you need help with?
+      options:
+        - Running `resqui` locally
+        - Writing or choosing a configuration file
+        - Understanding plugin output in `resqui_summary.json`
+        - Setting up the GitHub Action
+        - Tokens or authentication
+        - Extending resqui with a new plugin or indicator
+    validations:
+      required: true
+  - type: textarea
+    id: goal
+    attributes:
+      label: What are you trying to do?
+      description: Describe the repository you want to assess and the outcome you need.
+    validations:
+      required: true
+  - type: textarea
+    id: tried
+    attributes:
+      label: What have you already tried?
+      description: Include the command, config file, workflow snippet, or README section you used.
+      render: shell
+    validations:
+      required: true
+  - type: textarea
+    id: blocker
+    attributes:
+      label: What is still unclear or failing?
+      description: Paste the confusing output, error message, or decision you are stuck on.
+    validations:
+      required: true
+  - type: input
+    id: config
+    attributes:
+      label: Relevant configuration or workflow file
+      description: Provide the path if this depends on a file such as `configurations/basic.json` or `.github/workflows/resqui.yml`.
+    validations:
+      required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,20 @@
+## Summary
+
+Describe the change in terms of `resqui`, the composite action in `action.yml`, a configuration under `configurations/`, or a plugin/executor under `src/resqui/`.
+
+## Validation
+
+- [ ] I ran `make test` locally, or I cannot run it and explained why.
+- [ ] If I changed CLI behavior, configuration loading, or plugin results, I ran `resqui -c configurations/basic.json -t <token>` or explained why that was not possible.
+- [ ] If I changed packaging or installation behavior, I verified `make install-dev` and `pip install .` still work.
+
+## Review notes
+
+- [ ] This PR targets `main`.
+- [ ] I updated `README.md` if I changed CLI flags, action inputs, setup steps, output semantics, or the expected configuration format.
+- [ ] I updated files under `configurations/` if the default or reference indicator sets changed.
+- [ ] I added or updated tests in `tests/` when behavior changed.
+
+## Related issue
+
+Link the issue if there is one. If there is no issue, state the maintenance problem this PR resolves.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,95 @@
+# Contributing to resqui
+
+Thanks for helping improve resqui.
+
+## Scope of contributions
+
+Contributions are most useful when they improve one of these areas:
+
+- CLI behavior in src/resqui/cli.py and supporting core modules
+- Indicator plugins in src/resqui/plugins/
+- Executors in src/resqui/executors/
+- Reference configurations in configurations/
+- GitHub Action behavior in action.yml
+- Tests in tests/
+- User-facing docs in README.md
+
+## Local setup
+
+Use Python 3.9+.
+
+```bash
+python3 -m venv venv
+source venv/bin/activate
+make install-dev
+```
+
+## Make your change
+
+1. Create a branch from main.
+2. Keep changes focused and small.
+3. If behavior changes, add or update tests in tests/.
+4. If CLI options, action inputs, config format, or output semantics change, update README.md.
+
+## Validate before opening a PR
+
+Run:
+
+```bash
+make test
+```
+
+If your change affects runtime behavior, also run:
+
+```bash
+resqui -c configurations/basic.json -t <your_github_token>
+```
+
+If your change affects install or packaging, verify:
+
+```bash
+make install-dev
+pip install .
+```
+
+If you changed formatting-sensitive files, you can run:
+
+```bash
+make black
+```
+
+## Plugin and indicator contributions
+
+For new indicators or plugins:
+
+- Add or update plugin code in src/resqui/plugins/
+- Ensure indicator names map to plugin methods
+- Return CheckResult values with clear evidence text
+- Add or update matching entries in configurations/ when needed
+- Add tests that cover success and failure paths
+
+## Pull requests
+
+Open a PR targeting main and complete the checklist in .github/PULL_REQUEST_TEMPLATE.md.
+
+Include:
+
+- A clear summary of what changed
+- Validation commands you ran
+- Any follow-up work that is out of scope for the PR
+
+## Issues
+
+Use the issue forms under .github/ISSUE_TEMPLATE/:
+
+- Bug report
+- Plugin or indicator request
+- Usage question
+
+These forms help maintainers reproduce problems and review changes quickly.
+
+## Security and secrets
+
+Do not commit tokens, credentials, or private data.
+
+When sharing logs, remove sensitive values such as GitHub and DashVerse tokens.


### PR DESCRIPTION

This PR adds GitHub contribution templates (generated).

- structured issue forms for:
    - bug reports
    - plugin/indicator requests
    - usage questions

- a concise pull request template 
- CONTRIBUTING.md

Fixes #47 