### PR TITLE
add contributor check to improve recognition

### DIFF
--- a/.github/workflows/check_contributors.yml
+++ b/.github/workflows/check_contributors.yml
@@ -1,0 +1,22 @@
+name: Contributor Check
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+permissions:
+  contents: read
+  pull-requests: write # allows posting comments on PRs
+
+jobs:
+  contrib-check:
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Contributors metadata check
+        uses: vuillaut/contrib-checker@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          mode: warn 
+          ignore_emails: ""
+          ignore_logins: ""

--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,4 @@
+# .mailmap
+
+# Thomas Vuillaume
+# Thomas Vuillaume <thomas.vuillaume@lapp.in2p3.fr>  vuillaut <thomas.vuillaume@lapp.in2p3.fr>

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -8,10 +8,6 @@ authors:
     given-names: Tamas
     orcid: https://orcid.org/0000-0001-7821-8673
     affiliation: "Erlangen Centre for Astroparticle Physics, Friedrich-Alexander-Universität Erlangen-Nürnberg"
-  - family-names: Vuillaume
-    given-names: Thomas
-    orcid: https://orcid.org/0000-0002-5686-2078
-    affiliation: "LAPP, Université Savoie Mont-Blanc, CNRS"
 repository-code: https://github.com/EVERSE-ResearchSoftware/QualityPipelines
 url: https://github.com/EVERSE-ResearchSoftware/QualityPipelines
 abstract: A tool to check indicators related to research software quality.

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -8,6 +8,10 @@ authors:
     given-names: Tamas
     orcid: https://orcid.org/0000-0001-7821-8673
     affiliation: "Erlangen Centre for Astroparticle Physics, Friedrich-Alexander-Universität Erlangen-Nürnberg"
+  - family-names: Vuillaume
+    given-names: Thomas
+    orcid: https://orcid.org/0000-0002-5686-2078
+    affiliation: "LAPP, Université Savoie Mont-Blanc, CNRS"
 repository-code: https://github.com/EVERSE-ResearchSoftware/QualityPipelines
 url: https://github.com/EVERSE-ResearchSoftware/QualityPipelines
 abstract: A tool to check indicators related to research software quality.

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -3,11 +3,15 @@ message: "If you use this software, please cite it as below."
 type: software
 title: resqui
 authors:
+  - name: "The EVERSE project"
   - family-names: Gal
     given-names: Tamas
     orcid: https://orcid.org/0000-0001-7821-8673
     affiliation: "Erlangen Centre for Astroparticle Physics, Friedrich-Alexander-Universität Erlangen-Nürnberg"
-  - name: "EVERSE"
+  - family-names: Vuillaume
+    given-names: Thomas
+    orcid: https://orcid.org/0000-0002-5686-2078
+    affiliation: "LAPP, Université Savoie Mont-Blanc, CNRS"
 repository-code: https://github.com/EVERSE-ResearchSoftware/QualityPipelines
 url: https://github.com/EVERSE-ResearchSoftware/QualityPipelines
 abstract: A tool to check indicators related to research software quality.

--- a/codemeta.json
+++ b/codemeta.json
@@ -48,6 +48,17 @@
         "@type": "Organization",
         "name": "Erlangen Centre for Astroparticle Physics"
       }
+    },
+    {
+      "@id": "http://orcid.org/0000-0002-5686-2078",
+      "@type": "Person",
+      "givenName": "Thomas",
+      "familyName": "Vuillaume",
+      "email": "thomas.vuillaume@lapp.in2p3.fr",
+      "affiliation": {
+        "@type": "Organization",
+        "name": "LAPP, Université Savoie Mont-Blanc, CNRS"
+      }
     }
   ],
   "maintainer": [


### PR DESCRIPTION
Contributor Check makes sure all code contributors are added to `CITATION.cff` and `codemeta.json` by commenting in PRs when new contributors make a PR in the repository (see ⬇️ )