### PR TITLE
Add support for Zenodo DOIs and URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Usage:
     resqui indicators
 
 Options:
-    -u <repository_url>   URL of the repository to be analyzed.
+    -u <repository_url>   URL of the repository to be analyzed (GitHub URLs, Zenodo DOIs and URLs accepted)
     -c <config_file>      Path to the configuration file.
     -o <output_file>      Path to the output file [default: resqui_summary.json].
     -t <github_token>     GitHub API token.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "resqui"
 authors = [{ name = "Tamas Gal", email = "tamas.gal@fau.de" }]
 maintainers = [{ name = "Tamas Gal", email = "tamas.gal@fau.de" }]
-dependencies = ["setuptools_scm"]
+dependencies = ["setuptools_scm", "requests"]
 requires-python = ">=3.9"
 classifiers = [
     "Development Status :: 5 - Production/Stable",

--- a/src/resqui/cli.py
+++ b/src/resqui/cli.py
@@ -4,7 +4,7 @@ Usage:
     resqui indicators
 
 Options:
-    -u <repository_url>   URL of the repository to be analyzed.
+    -u <repository_url>   URL of the repository to be analyzed (GitHub URLs, Zenodo DOIs and URLs accepted).
     -c <config_file>      Path to the configuration file.
     -o <output_file>      Path to the output file [default: resqui_summary.json].
     -t <github_token>     GitHub API token.
@@ -27,7 +27,14 @@ import tempfile
 
 from resqui.core import Context, Summary
 from resqui.config import Configuration
-from resqui.tools import indented, to_https, project_name_from_url, ensure_list
+from resqui.tools import (
+    indented,
+    is_zenodo_url,
+    to_https,
+    project_name_from_url,
+    ensure_list,
+    zenodo_url_to_git,
+)
 from resqui.plugins import IndicatorPlugin, PluginInitError
 from resqui.executors import ExecutorInitError
 from resqui.docopt import docopt
@@ -144,6 +151,9 @@ def resqui():
             )
             exit(1)
     else:
+        if is_zenodo_url(url):
+            url, branch = zenodo_url_to_git(url)
+
         temp_dir = tempfile.mkdtemp()
         try:
             subprocess.run(

--- a/src/resqui/tools.py
+++ b/src/resqui/tools.py
@@ -1,5 +1,7 @@
 import re
 
+import requests
+
 
 def normalized(script):
     """
@@ -40,6 +42,14 @@ def construct_full_url(url, branch_hash_or_tag):
     return f"{repo_url}/{midfix}/{branch_hash_or_tag}"
 
 
+def url_branch_from_full_url(full_url):
+    # https://github.com/user/repo/tree/v1.2.3
+    m = re.match(r"(https://github.com/[^/]+/[^/]+)/(commit|tree)/(.+)", full_url)
+    if m:
+        url, _, branch_hash_or_tag = m.groups()
+        return [url, branch_hash_or_tag]
+
+
 def to_https(url):
     if url.startswith("http://") or url.startswith("https://"):
         return url
@@ -66,3 +76,47 @@ def project_name_from_url(url):
 def ensure_list(item):
     """Wraps the item into a list if it is not already a list"""
     return item if isinstance(item, list) else [item]
+
+
+def is_zenodo_url(url):
+    return url.startswith("https://doi.org/10.5281/zenodo.") or url.startswith(
+        "https://zenodo.org/records/"
+    )
+
+
+def zenodo_url_to_git(url):
+    headers = {
+        "User-Agent": "EVERSE resqui (+https://everse.software/QualityPipelines/)"
+    }
+
+    # Parsing FAIR Signposting headers to find the URL of the REST API endpoint.
+    r = requests.get(url, headers=headers)
+    links = r.headers.get("Link", "").split(",")
+    for link in links:
+        [uri, *parameters] = link.split(";")
+
+        parameters_dict = {}
+        for parameter in parameters:
+            [key, value] = parameter.split("=")
+            parameters_dict[key.strip()] = value.strip()
+
+        if (
+            parameters_dict.get("rel") == '"describedby"'
+            and parameters_dict.get("type") == '"application/json"'
+        ):
+            # The URI is enclosed in angled brackets.
+            rest_uri = uri.strip()[1:-1]
+
+            # Extracting the Git URL from the REST API endpoint.
+            r = requests.get(
+                rest_uri, headers={**headers, "Accept": "application/json"}
+            )
+            for related_identifier in r.json()["metadata"].get(
+                "related_identifiers", {}
+            ):
+                if "://github.com/" in related_identifier["identifier"]:
+                    full_url = related_identifier["identifier"]
+                    url, branch = url_branch_from_full_url(full_url)
+                    return [url, branch]
+
+    raise ValueError("No Git repository found for Zenodo URL")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -415,6 +415,47 @@ class TestResquiMainPath(unittest.TestCase):
             with self.assertRaises(sp.CalledProcessError):
                 resqui()
 
+    def test_clone_zenodo_url_path(self):
+        def mock_requests_get(url, headers=None):
+            if url == "https://doi.org/10.5281/zenodo.18713816":
+                mock_response = MagicMock()
+                mock_response.headers = {
+                    "Link": '<https://zenodo.org/api/records/20553350> ; rel="describedby" ; type="application/json"'
+                }
+                return mock_response
+
+            elif (
+                url == "https://zenodo.org/api/records/20553350"
+                and headers.get("Accept") == "application/json"
+            ):
+                mock_response = MagicMock()
+                mock_response.json.return_value = {
+                    "metadata": {
+                        "related_identifiers": [
+                            {
+                                "identifier": "https://github.com/EVERSE-ResearchSoftware/QualityPipelines/tree/v0.2.0",
+                                "relation": "isSupplementTo",
+                                "resource_type": "software",
+                                "scheme": "url",
+                            }
+                        ]
+                    }
+                }
+                return mock_response
+
+            else:
+                raise ValueError(f"Unsupported URL '{url}' and headers '{headers}'")
+
+        with self._patches(
+            argv=["resqui", "-u", "https://doi.org/10.5281/zenodo.18713816"],
+            **{
+                "requests.get": MagicMock(side_effect=mock_requests_get),
+                "resqui.cli.subprocess.run": MagicMock(),
+            },
+        ):
+            resqui()
+        self.summary.write.assert_called_once()
+
 
 class TestPrintIndicatorPluginsNoIndicators(unittest.TestCase):
     """Cover the '(none)' branch for a plugin that declares no indicators."""

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1,5 +1,6 @@
 import unittest
 from resqui.tools import (
+    is_zenodo_url,
     normalized,
     indented,
     is_commit_hash,
@@ -7,6 +8,7 @@ from resqui.tools import (
     to_https,
     project_name_from_url,
     ensure_list,
+    url_branch_from_full_url,
 )
 
 VALID_HASH = "a" * 40
@@ -84,6 +86,18 @@ class TestConstructFullUrl(unittest.TestCase):
         self.assertNotIn(".git", url)
 
 
+class TestUrlBranchFromFullUrl(unittest.TestCase):
+    BASE = "https://github.com/user/repo"
+
+    def test_branch(self):
+        url = url_branch_from_full_url(f"{self.BASE}/tree/main")
+        self.assertIn("main", url)
+
+    def test_commit_hash(self):
+        url = url_branch_from_full_url(f"{self.BASE}/commit/{VALID_HASH}")
+        self.assertIn(VALID_HASH, url)
+
+
 class TestToHttps(unittest.TestCase):
     def test_https_unchanged(self):
         url = "https://github.com/user/repo"
@@ -132,3 +146,14 @@ class TestEnsureList(unittest.TestCase):
 
     def test_none_is_wrapped(self):
         self.assertEqual(ensure_list(None), [None])
+
+
+class TestIsZenodoUrl(unittest.TestCase):
+    def test_doi_url(self):
+        self.assertTrue(is_zenodo_url("https://doi.org/10.5281/zenodo.87654321"))
+
+    def test_zenodo_url(self):
+        self.assertTrue(is_zenodo_url("https://zenodo.org/records/87654321"))
+
+    def test_other_url(self):
+        self.assertFalse(is_zenodo_url("https://example.com/"))


### PR DESCRIPTION
Fixes #76 

Detects the GitHub repository URL and tag from a Zenodo DOI or URL (and run the analysis on this GitHub repository).