### PR TITLE
Add shared Docker workspace support for plugin execution

### DIFF
--- a/src/resqui/plugins/gitleaks.py
+++ b/src/resqui/plugins/gitleaks.py
@@ -1,12 +1,11 @@
 import json
 import subprocess
-import tempfile
-import shutil
 import os
 
 from resqui.plugins.base import IndicatorPlugin
 from resqui.executors import DockerExecutor
 from resqui.core import CheckResult
+from resqui.workspace import create_workspace
 
 
 class Gitleaks(IndicatorPlugin):
@@ -21,29 +20,37 @@ class Gitleaks(IndicatorPlugin):
         self.executor = DockerExecutor(self.image_url)
 
     def has_no_security_leak(self, url, branch_hash_or_tag):
-        temp_dir = tempfile.mkdtemp()
         report_fname = "report.json"
 
-        try:
-            subprocess.run(
-                ["git", "clone", url, temp_dir],
-                check=True,
-                stdout=subprocess.DEVNULL,
-                stderr=subprocess.DEVNULL,
+        # Implementacion anterior sustituida para SQOO:
+        # temp_dir = tempfile.mkdtemp()
+        # run_args = ["-v", f"{temp_dir}:/path"]
+        # p = self.executor.run(
+        #     ["git", "/path", "-r", f"/path/{report_fname}"], run_args=run_args
+        # )
+
+        # Implementacion para SQOO: el workspace puede vivir en un volumen Docker
+        # compartido para que el worker y el contenedor del plugin vean la misma ruta.
+        with create_workspace(prefix="resqui-gitleaks-") as workspace:
+            try:
+                subprocess.run(
+                    ["git", "clone", url, workspace.local_path],
+                    check=True,
+                    stdout=subprocess.DEVNULL,
+                    stderr=subprocess.DEVNULL,
+                )
+            except subprocess.CalledProcessError as e:
+                print(f"Error cloning {url}: {e}")
+                raise
+
+            plugin_path = workspace.container_path("/path")
+            report_path = f"{plugin_path}/{report_fname}"
+            run_args = workspace.docker_mount_args("/path")
+            p = self.executor.run(
+                ["git", plugin_path, "-r", report_path], run_args=run_args
             )
-        except subprocess.CalledProcessError as e:
-            print(f"Error cloning {url}: {e}")
-            raise
-
-        run_args = ["-v", f"{temp_dir}:/path"]
-        p = self.executor.run(
-            ["git", "/path", "-r", f"/path/{report_fname}"], run_args=run_args
-        )
-        with open(os.path.join(temp_dir, report_fname)) as f:
-            report = json.load(f)
-
-        if os.path.exists(temp_dir):
-            shutil.rmtree(temp_dir)
+            with open(os.path.join(workspace.local_path, report_fname)) as f:
+                report = json.load(f)
 
         if "no leaks found" in p.stderr and not report:
             output = "secure"

--- a/src/resqui/plugins/rsfc.py
+++ b/src/resqui/plugins/rsfc.py
@@ -1,11 +1,10 @@
 import json
-import tempfile
 import os
-import shutil
 
 from resqui.plugins.base import IndicatorPlugin
 from resqui.executors import DockerExecutor
 from resqui.core import CheckResult
+from resqui.workspace import create_workspace
 
 
 class RSFC(IndicatorPlugin):
@@ -39,28 +38,49 @@ class RSFC(IndicatorPlugin):
         if cache_key in self._cache:
             return self._cache[cache_key]
 
-        tempdir = tempfile.mkdtemp()
-
         url = url.removesuffix(".git")
 
-        run_args = [
-            "--rm",
-            "-v",
-            f"{tempdir}:/rsfc/rsfc_output",
-        ]
-
-        _ = self.executor.run(["--repo", url], run_args=run_args)
-
         assessment_filename = "rsfc_assessment.json"
-        assessment_fpath = os.path.join(tempdir, assessment_filename)
-        if not os.path.isfile(os.path.join(tempdir, assessment_filename)):
-            msg = f"Error: RSFC did not generate the expected assessment file named '{assessment_filename}'"
-            raise FileNotFoundError(msg)
 
-        with open(assessment_fpath) as f:
-            report = json.load(f)
+        # Implementacion anterior sustituida para SQOO:
+        # tempdir = tempfile.mkdtemp()
+        # run_args = [
+        #     "--rm",
+        #     "-v",
+        #     f"{tempdir}:/rsfc/rsfc_output",
+        # ]
+        # _ = self.executor.run(["--repo", url], run_args=run_args)
+        # assessment_fpath = os.path.join(tempdir, assessment_filename)
 
-        shutil.rmtree(tempdir)
+        # Implementacion para SQOO: en modo worker se monta el volumen compartido
+        # y se cambia el workdir para que RSFC escriba dentro del workspace aislado.
+        with create_workspace(prefix="resqui-rsfc-") as workspace:
+            if workspace.is_shared:
+                container_workspace = workspace.container_path("/rsfc")
+                run_args = [
+                    "--rm",
+                    *workspace.docker_mount_args("/rsfc"),
+                    "-w",
+                    container_workspace,
+                ]
+                assessment_fpath = os.path.join(
+                    workspace.local_path, "rsfc_output", assessment_filename
+                )
+            else:
+                run_args = [
+                    "--rm",
+                    *workspace.docker_mount_args("/rsfc/rsfc_output"),
+                ]
+                assessment_fpath = os.path.join(workspace.local_path, assessment_filename)
+
+            _ = self.executor.run(["--repo", url], run_args=run_args)
+
+            if not os.path.isfile(assessment_fpath):
+                msg = f"Error: RSFC did not generate the expected assessment file named '{assessment_filename}'"
+                raise FileNotFoundError(msg)
+
+            with open(assessment_fpath) as f:
+                report = json.load(f)
 
         self._cache[cache_key] = report
 

--- a/src/resqui/plugins/superlinter.py
+++ b/src/resqui/plugins/superlinter.py
@@ -1,12 +1,10 @@
 import platform
 import subprocess
-import tempfile
-import shutil
-import os
 
 from resqui.plugins import IndicatorPlugin
 from resqui.executors import DockerExecutor
 from resqui.core import CheckResult
+from resqui.workspace import create_workspace
 
 
 class SuperLinter(IndicatorPlugin):
@@ -23,33 +21,45 @@ class SuperLinter(IndicatorPlugin):
         self.executor = DockerExecutor(self.image_url, pull_args=pull_args)
 
     def has_no_linting_issues(self, url, branch):
-        temp_dir = tempfile.mkdtemp()
+        # Implementacion anterior sustituida para SQOO:
+        # temp_dir = tempfile.mkdtemp()
+        # run_args = [
+        #     "-e",
+        #     "RUN_LOCAL=true",
+        #     "-e",
+        #     f"DEFAULT_BRANCH={branch}",
+        #     "-v",
+        #     f"{temp_dir}:/tmp/lint",
+        # ]
+        # p = self.executor.run([], run_args=run_args)
 
-        try:
-            subprocess.run(
-                ["git", "clone", url, temp_dir],
-                check=True,
-                stdout=subprocess.DEVNULL,
-                stderr=subprocess.DEVNULL,
-            )
-        except subprocess.CalledProcessError as e:
-            print(f"Error cloning {url}: {e}")
-            raise
+        # Implementacion para SQOO: el workspace compartido evita montar rutas
+        # /tmp internas del worker que el Docker daemon del host no puede ver.
+        with create_workspace(prefix="resqui-superlinter-") as workspace:
+            try:
+                subprocess.run(
+                    ["git", "clone", url, workspace.local_path],
+                    check=True,
+                    stdout=subprocess.DEVNULL,
+                    stderr=subprocess.DEVNULL,
+                )
+            except subprocess.CalledProcessError as e:
+                print(f"Error cloning {url}: {e}")
+                raise
 
-        run_args = [
-            #            "-e",
-            #            "LOG_LEVEL=DEBUG",
-            "-e",
-            "RUN_LOCAL=true",
-            "-e",
-            f"DEFAULT_BRANCH={branch}",
-            "-v",
-            f"{temp_dir}:/tmp/lint",
-        ]
-        p = self.executor.run([], run_args=run_args)
-
-        if os.path.exists(temp_dir):
-            shutil.rmtree(temp_dir)
+            lint_path = workspace.container_path("/tmp/lint")
+            run_args = [
+                #            "-e",
+                #            "LOG_LEVEL=DEBUG",
+                "-e",
+                "RUN_LOCAL=true",
+                "-e",
+                f"DEFAULT_BRANCH={branch}",
+                "-e",
+                f"DEFAULT_WORKSPACE={lint_path}",
+                *workspace.docker_mount_args("/tmp/lint"),
+            ]
+            p = self.executor.run([], run_args=run_args)
 
         if "Super-linter detected linting errors" in p.stdout:
             output = "invalid"

--- a/src/resqui/workspace.py
+++ b/src/resqui/workspace.py
@@ -1,0 +1,69 @@
+import os
+import shutil
+import tempfile
+from dataclasses import dataclass
+
+
+SHARED_WORKDIR_ENV = "RESQUI_SHARED_WORKDIR"
+DOCKER_WORK_VOLUME_ENV = "RESQUI_DOCKER_WORK_VOLUME"
+
+
+@dataclass(frozen=True)
+class Workspace:
+    """Workspace visible to resqui and, optionally, Docker plugin containers."""
+
+    local_path: str
+    shared_root: str | None = None
+    docker_volume: str | None = None
+
+    @property
+    def is_shared(self) -> bool:
+        return self.shared_root is not None and self.docker_volume is not None
+
+    def container_path(self, fallback_path: str) -> str:
+        """Return the path the plugin container should use for this workspace."""
+        if self.is_shared:
+            return self.local_path
+        return fallback_path
+
+    def docker_mount_args(self, fallback_path: str) -> list[str]:
+        """Return Docker -v arguments for exposing this workspace to a plugin."""
+        if self.is_shared:
+            return ["-v", f"{self.docker_volume}:{self.shared_root}"]
+        return ["-v", f"{self.local_path}:{fallback_path}"]
+
+    def cleanup(self) -> None:
+        shutil.rmtree(self.local_path, ignore_errors=True)
+
+    def __enter__(self) -> "Workspace":
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback) -> None:
+        self.cleanup()
+
+
+def create_workspace(prefix: str = "resqui-") -> Workspace:
+    """Create a temporary workspace for local and Docker-backed plugin runs.
+
+    By default, this behaves like tempfile.mkdtemp(). In SQOO worker mode, set
+    RESQUI_SHARED_WORKDIR and RESQUI_DOCKER_WORK_VOLUME so plugin containers can
+    mount the same Docker volume that the worker uses.
+    """
+    shared_root = os.getenv(SHARED_WORKDIR_ENV)
+    docker_volume = os.getenv(DOCKER_WORK_VOLUME_ENV)
+
+    if bool(shared_root) != bool(docker_volume):
+        raise ValueError(
+            f"{SHARED_WORKDIR_ENV} and {DOCKER_WORK_VOLUME_ENV} must be set together"
+        )
+
+    if shared_root and docker_volume:
+        os.makedirs(shared_root, exist_ok=True)
+        local_path = tempfile.mkdtemp(prefix=prefix, dir=shared_root)
+        return Workspace(
+            local_path=os.path.abspath(local_path),
+            shared_root=os.path.abspath(shared_root),
+            docker_volume=docker_volume,
+        )
+
+    return Workspace(local_path=tempfile.mkdtemp(prefix=prefix))

--- a/tests/test_plugins_workspace.py
+++ b/tests/test_plugins_workspace.py
@@ -1,0 +1,98 @@
+import json
+import os
+import tempfile
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from resqui.core import Context
+from resqui.plugins.gitleaks import Gitleaks
+from resqui.plugins.rsfc import RSFC
+from resqui.plugins.superlinter import SuperLinter
+
+
+class FakeExecutor:
+    def __init__(self, stdout="", stderr=""):
+        self.stdout = stdout
+        self.stderr = stderr
+        self.calls = []
+
+    def run(self, command, run_args=None):
+        run_args = run_args or []
+        self.calls.append((command, run_args))
+        return SimpleNamespace(stdout=self.stdout, stderr=self.stderr)
+
+
+class TestPluginSharedWorkspace(unittest.TestCase):
+    def _env(self, root):
+        return {
+            "RESQUI_SHARED_WORKDIR": root,
+            "RESQUI_DOCKER_WORK_VOLUME": "sqoo_resqui_work",
+        }
+
+    def test_gitleaks_uses_shared_workspace_volume(self):
+        def fake_clone(args, **kwargs):
+            os.makedirs(args[3], exist_ok=True)
+            with open(os.path.join(args[3], "report.json"), "w") as f:
+                json.dump([], f)
+
+        plugin = Gitleaks.__new__(Gitleaks)
+        plugin.context = Context(github_token="token")
+        plugin.executor = FakeExecutor(stderr="no leaks found")
+
+        with tempfile.TemporaryDirectory() as root:
+            with patch.dict(os.environ, self._env(root), clear=True):
+                with patch("resqui.plugins.gitleaks.subprocess.run", side_effect=fake_clone):
+                    plugin.has_no_security_leak("https://github.com/example/repo", "main")
+
+        command, run_args = plugin.executor.calls[0]
+        self.assertEqual(run_args, ["-v", f"sqoo_resqui_work:{root}"])
+        self.assertTrue(command[1].startswith(root))
+        self.assertTrue(command[3].startswith(root))
+
+    def test_superlinter_uses_shared_workspace_volume(self):
+        plugin = SuperLinter.__new__(SuperLinter)
+        plugin.context = Context(github_token="token")
+        plugin.executor = FakeExecutor(stdout="")
+
+        with tempfile.TemporaryDirectory() as root:
+            with patch.dict(os.environ, self._env(root), clear=True):
+                with patch("resqui.plugins.superlinter.subprocess.run"):
+                    plugin.has_no_linting_issues("https://github.com/example/repo", "main")
+
+        _, run_args = plugin.executor.calls[0]
+        self.assertIn("-v", run_args)
+        self.assertIn(f"sqoo_resqui_work:{root}", run_args)
+        self.assertIn("-e", run_args)
+        workspace_index = run_args.index("-e", run_args.index("DEFAULT_BRANCH=main") + 1)
+        self.assertTrue(run_args[workspace_index + 1].startswith("DEFAULT_WORKSPACE=" + root))
+
+    def test_rsfc_uses_shared_workspace_volume(self):
+        def fake_rsfc_run(command, run_args=None):
+            run_args = run_args or []
+            workdir = run_args[run_args.index("-w") + 1]
+            output_dir = os.path.join(workdir, "rsfc_output")
+            os.makedirs(output_dir, exist_ok=True)
+            assessment_path = os.path.join(output_dir, "rsfc_assessment.json")
+            with open(assessment_path, "w") as f:
+                json.dump({"checks": []}, f)
+            fake_executor.calls.append((command, run_args))
+            return SimpleNamespace(stdout="", stderr="")
+
+        fake_executor = FakeExecutor()
+        fake_executor.run = fake_rsfc_run
+
+        plugin = RSFC.__new__(RSFC)
+        plugin.context = Context(github_token="token")
+        plugin.executor = fake_executor
+        plugin._cache = {}
+
+        with tempfile.TemporaryDirectory() as root:
+            with patch.dict(os.environ, self._env(root), clear=True):
+                plugin.execute("https://github.com/example/repo", "main")
+
+        _, run_args = fake_executor.calls[0]
+        self.assertIn("-v", run_args)
+        self.assertIn(f"sqoo_resqui_work:{root}", run_args)
+        self.assertIn("-w", run_args)
+        self.assertTrue(run_args[run_args.index("-w") + 1].startswith(root))

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -1,0 +1,58 @@
+import os
+import tempfile
+import unittest
+from unittest.mock import patch
+
+from resqui.workspace import create_workspace
+
+
+class TestWorkspace(unittest.TestCase):
+    def test_local_workspace_mounts_temp_dir_to_requested_container_path(self):
+        with patch.dict(os.environ, {}, clear=True):
+            workspace = create_workspace(prefix="test-resqui-")
+
+        try:
+            self.assertTrue(os.path.isdir(workspace.local_path))
+            self.assertEqual(workspace.container_path("/path"), "/path")
+            self.assertEqual(
+                workspace.docker_mount_args("/path"),
+                ["-v", f"{workspace.local_path}:/path"],
+            )
+        finally:
+            workspace.cleanup()
+
+        self.assertFalse(os.path.exists(workspace.local_path))
+
+    def test_shared_workspace_mounts_named_volume_and_keeps_same_path(self):
+        with tempfile.TemporaryDirectory() as root:
+            with patch.dict(
+                os.environ,
+                {
+                    "RESQUI_SHARED_WORKDIR": root,
+                    "RESQUI_DOCKER_WORK_VOLUME": "sqoo_resqui_work",
+                },
+                clear=True,
+            ):
+                workspace = create_workspace(prefix="test-resqui-")
+
+            try:
+                self.assertTrue(workspace.local_path.startswith(root))
+                self.assertTrue(os.path.isdir(workspace.local_path))
+                self.assertEqual(workspace.container_path("/path"), workspace.local_path)
+                self.assertEqual(
+                    workspace.docker_mount_args("/path"),
+                    ["-v", f"sqoo_resqui_work:{root}"],
+                )
+            finally:
+                workspace.cleanup()
+
+            self.assertFalse(os.path.exists(workspace.local_path))
+
+    def test_partial_shared_workspace_configuration_is_rejected(self):
+        with patch.dict(
+            os.environ,
+            {"RESQUI_SHARED_WORKDIR": "/resqui-work"},
+            clear=True,
+        ):
+            with self.assertRaises(ValueError):
+                create_workspace()


### PR DESCRIPTION
# Shared Docker workspace support for worker-based execution

## Summary

This PR prepares RESQUI plugins to run both locally and inside Docker workers that launch additional Docker containers for plugin execution.

The change preserves the existing local behavior and adds an optional shared-workspace mode for orchestrators such as SQOO, where RESQUI runs inside a worker container and plugins run as child containers through the host Docker socket.

## Problem

When RESQUI runs inside a worker container, the Gitleaks, Super-Linter, and RSFC plugins launch additional Docker containers. Previously, each plugin created temporary directories inside the RESQUI container and mounted those paths directly into the plugin container.

That approach fails in Docker-outside-of-Docker setups using `/var/run/docker.sock`, because the host Docker daemon cannot mount temporary paths that only exist inside the worker container filesystem. As a result, plugin containers cannot see the cloned repositories or the expected output files.

## Solution

This PR adds a workspace helper in `src/resqui/workspace.py` with two execution modes:

- Default local mode: if no additional configuration is provided, RESQUI keeps using a local temporary directory and mounts it as before.
- Shared workspace mode: if `RESQUI_SHARED_WORKDIR` and `RESQUI_DOCKER_WORK_VOLUME` are configured, RESQUI creates workspaces inside a shared path and mounts the Docker volume that is visible to the host daemon into plugin containers.

New environment variables:

```text
RESQUI_SHARED_WORKDIR=/resqui-work
RESQUI_DOCKER_WORK_VOLUME=sqoo_resqui_work
```

Both variables must be set together. If only one of them is set, the helper fails explicitly to avoid inconsistent configuration.

## Main changes

### `src/resqui/workspace.py`

New module responsible for creating and cleaning execution workspaces.

It exposes:

- `create_workspace(...)`: creates either a local temporary workspace or a shared workspace depending on environment variables.
- `Workspace.container_path(...)`: returns the path that should be used inside the plugin container.
- `Workspace.docker_mount_args(...)`: builds the correct Docker `-v` mount arguments.
- `Workspace.cleanup()`: removes the workspace after execution.

### `src/resqui/plugins/gitleaks.py`

Gitleaks now clones the repository into a workspace managed by `create_workspace`.

In SQOO mode, the plugin mounts the shared Docker volume instead of trying to mount a temporary path that only exists inside the worker container. The `report.json` file is still read from the local workspace path.

The previous implementation has also been left commented to document which part is replaced by the SQOO integration.

### `src/resqui/plugins/superlinter.py`

Super-Linter now uses the shared workspace and sets `DEFAULT_WORKSPACE` to the path visible inside the plugin container.

This allows Super-Linter to analyze the cloned repository even when RESQUI is running inside a Docker worker.

The previous implementation has also been left commented to document which part is replaced by the SQOO integration.

### `src/resqui/plugins/rsfc.py`

RSFC now distinguishes between:

- Local mode: keeps the previous mount behavior targeting `/rsfc/rsfc_output`.
- SQOO mode: mounts the shared volume and uses `-w` to run RSFC from the shared workspace, so `rsfc_output/rsfc_assessment.json` is generated in a path visible to the worker.

The previous implementation has also been left commented to document which part is replaced by the SQOO integration.

## Compatibility

This change is backward compatible:

- If `RESQUI_SHARED_WORKDIR` and `RESQUI_DOCKER_WORK_VOLUME` are not set, RESQUI keeps working in local mode.
- If both variables are set, RESQUI enables shared-workspace mode for Docker workers.

## Docker configuration example

```yaml
services:
  worker_resqui:
    environment:
      - RESQUI_SHARED_WORKDIR=/resqui-work
      - RESQUI_DOCKER_WORK_VOLUME=sqoo_resqui_work
    volumes:
      - resqui_work:/resqui-work
      - /var/run/docker.sock:/var/run/docker.sock

volumes:
  resqui_work:
    name: sqoo_resqui_work
```

## Tests

Tests were added to validate that all three plugins use the shared workspace correctly:

- Gitleaks mounts the shared Docker volume.
- Super-Linter uses `DEFAULT_WORKSPACE` pointing to the shared path.
- RSFC mounts the shared volume and runs the plugin container with the proper working directory.

Commands executed:

```powershell
$env:PYTHONPATH='src'
python -m pytest tests\test_workspace.py tests\test_plugins_workspace.py
python -m compileall src\resqui
```

Result:

```text
6 passed
compileall OK
```

## SQOO motivation

This change allows RESQUI to be integrated into SQOO with RabbitMQ-based parallel workers without breaking local RESQUI execution. In SQOO, workers can process jobs in parallel while Docker-based plugins still access repositories and outputs through a controlled shared volume.
