### PR TITLE
orgs confs

### DIFF
--- a/configurations/elixir_configuration.json
+++ b/configurations/elixir_configuration.json
@@ -1,0 +1,12 @@
+{
+  "indicators": [
+    {"name": "static_analysis_common_vulnerabilities","plugin": "OpenSSFScorecard","@id": "https://w3id.org/everse/i/indicators/static_analysis_common_vulnerabilities"},
+    {"name": "versioning_standards_use","plugin": "RSFC","@id": "https://w3id.org/everse/i/indicators/versioning_standards_use"},
+    {"name": "descriptive_metadata","plugin": "RSFC","@id": "https://w3id.org/everse/i/indicators/descriptive_metadata"},
+    {"name": "software_has_documentation","plugin": "RSFC","@id": "https://w3id.org/everse/i/indicators/software_has_documentation"},
+    {"name": "software_has_license", "plugin": "RSFC", "@id": "https://w3id.org/everse/i/indicators/software_has_license" },
+    {"name": "archived_in_software_heritage","plugin": "RSFC","@id": "https://w3id.org/everse/i/indicators/archived_in_software_heritage"},
+    {"name": "software_has_tests","plugin": "RSFC","@id": "https://w3id.org/everse/i/indicators/software_has_tests"},
+    { "name": "listed_in_registry", "plugin": "OEBFAIR", "@id": "https://w3id.org/everse/i/indicators/listed_in_registry" }
+  ]
+}

--- a/configurations/elixir_configuration.json
+++ b/configurations/elixir_configuration.json
@@ -6,8 +6,9 @@
     {"name": "software_has_documentation","plugin": "RSFC","@id": "https://w3id.org/everse/i/indicators/software_has_documentation"},
     {"name": "software_has_license", "plugin": "RSFC", "@id": "https://w3id.org/everse/i/indicators/software_has_license" },
     {"name": "archived_in_software_heritage","plugin": "RSFC","@id": "https://w3id.org/everse/i/indicators/archived_in_software_heritage"},
-    {"name": "software_has_tests","plugin": "RSFC","@id": "https://w3id.org/everse/i/indicators/software_has_tests"}
-  ],
+    {"name": "software_has_tests","plugin": "RSFC","@id": "https://w3id.org/everse/i/indicators/software_has_tests"},
+    { "name": "listed_in_registry", "plugin": "OEBFAIR", "@id": "https://w3id.org/everse/i/indicators/listed_in_registry" }
+],
     "comment": "Indicators for ELIXIR Cluster as defined by the community perspective https://everse.software/indicators/website/community.html, not implemented indicators are: software has sufficient test coverage, software is archived in a scholarly registry"
 
 }

--- a/configurations/elixir_configuration.json
+++ b/configurations/elixir_configuration.json
@@ -8,5 +8,7 @@
     {"name": "archived_in_software_heritage","plugin": "RSFC","@id": "https://w3id.org/everse/i/indicators/archived_in_software_heritage"},
     {"name": "software_has_tests","plugin": "RSFC","@id": "https://w3id.org/everse/i/indicators/software_has_tests"},
     { "name": "listed_in_registry", "plugin": "OEBFAIR", "@id": "https://w3id.org/everse/i/indicators/listed_in_registry" }
-  ]
+  ],
+    "comment": "Indicators for ELIXIR Cluster as defined by the community perspective https://everse.software/indicators/website/community.html, not implemented indicators are: software has sufficient test coverage, software is archived in a scholarly registry"
+
 }

--- a/configurations/elixir_configuration.json
+++ b/configurations/elixir_configuration.json
@@ -6,8 +6,7 @@
     {"name": "software_has_documentation","plugin": "RSFC","@id": "https://w3id.org/everse/i/indicators/software_has_documentation"},
     {"name": "software_has_license", "plugin": "RSFC", "@id": "https://w3id.org/everse/i/indicators/software_has_license" },
     {"name": "archived_in_software_heritage","plugin": "RSFC","@id": "https://w3id.org/everse/i/indicators/archived_in_software_heritage"},
-    {"name": "software_has_tests","plugin": "RSFC","@id": "https://w3id.org/everse/i/indicators/software_has_tests"},
-    { "name": "listed_in_registry", "plugin": "OEBFAIR", "@id": "https://w3id.org/everse/i/indicators/listed_in_registry" }
+    {"name": "software_has_tests","plugin": "RSFC","@id": "https://w3id.org/everse/i/indicators/software_has_tests"}
   ],
     "comment": "Indicators for ELIXIR Cluster as defined by the community perspective https://everse.software/indicators/website/community.html, not implemented indicators are: software has sufficient test coverage, software is archived in a scholarly registry"
 

--- a/configurations/hsf_configuration.json
+++ b/configurations/hsf_configuration.json
@@ -1,0 +1,12 @@
+{
+  "indicators": [
+    {"name": "versioning_standards_use","plugin": "RSFC","@id": "https://w3id.org/everse/i/indicators/versioning_standards_use"},
+    {"name": "software_has_documentation","plugin": "RSFC","@id": "https://w3id.org/everse/i/indicators/software_has_documentation"},
+    {"name": "software_has_license", "plugin": "RSFC", "@id": "https://w3id.org/everse/i/indicators/software_has_license" },
+    {"name": "version_control_use","plugin": "RSFC","@id": "https://w3id.org/everse/i/indicators/version_control_use"},
+    {"name": "software_has_tests","plugin": "RSFC","@id": "https://w3id.org/everse/i/indicators/software_has_tests"},
+    {"name": "has_contribution_guidelines","plugin": "RSFC","@id": "https://w3id.org/everse/i/indicators/has_contribution_guidelines"},
+    {"name": "requirements_specified","plugin": "RSFC","@id": "https://w3id.org/everse/i/indicators/requirements_specified"},
+    {"name": "support_issue_tracking","plugin": "RSFC","@id": "https://w3id.org/everse/i/indicators/support_issue_tracking"}
+  ]
+}

--- a/configurations/hsf_configuration.json
+++ b/configurations/hsf_configuration.json
@@ -6,7 +6,8 @@
     {"name": "version_control_use","plugin": "RSFC","@id": "https://w3id.org/everse/i/indicators/version_control_use"},
     {"name": "software_has_tests","plugin": "RSFC","@id": "https://w3id.org/everse/i/indicators/software_has_tests"},
     {"name": "has_contribution_guidelines","plugin": "RSFC","@id": "https://w3id.org/everse/i/indicators/has_contribution_guidelines"},
-    {"name": "requirements_specified","plugin": "RSFC","@id": "https://w3id.org/everse/i/indicators/requirements_specified"},
-    {"name": "support_issue_tracking","plugin": "RSFC","@id": "https://w3id.org/everse/i/indicators/support_issue_tracking"}
-  ]
+    {"name": "requirements_specified","plugin": "RSFC","@id": "https://w3id.org/everse/i/indicators/requirements_specified"}
+  ],
+    "comment": "Indicators for HEP Software Foundation (HSF) as defined by the community perspective https://everse.software/indicators/website/community.html, not implemented indicators are: software has communication channels, has issue tracking"
+
 }

--- a/configurations/ossr_configuration.json
+++ b/configurations/ossr_configuration.json
@@ -5,5 +5,7 @@
     {"name": "has_releases","plugin": "RSFC","@id": "https://w3id.org/everse/i/indicators/has_releases"},
     {"name": "has_published_package","plugin": "OpenSSFScorecard","@id": "https://w3id.org/everse/i/indicators/has_published_package"},
     {"name": "version_control_use","plugin": "RSFC","@id": "https://w3id.org/everse/i/indicators/version_control_use"}
-  ]
+  ],
+    "comment": "Indicators for ESCAPE Cluster (OSSR)  as defined by the community perspective https://everse.software/indicators/website/community.html, not implemented indicators are: has a container file"
+
 }

--- a/configurations/ossr_configuration.json
+++ b/configurations/ossr_configuration.json
@@ -1,0 +1,9 @@
+{
+  "indicators": [
+    {"name": "descriptive_metadata","plugin": "RSFC","@id": "https://w3id.org/everse/i/indicators/descriptive_metadata"},
+    {"name": "software_has_license", "plugin": "RSFC", "@id": "https://w3id.org/everse/i/indicators/software_has_license" },
+    {"name": "has_releases","plugin": "RSFC","@id": "https://w3id.org/everse/i/indicators/has_releases"},
+    {"name": "has_published_package","plugin": "OpenSSFScorecard","@id": "https://w3id.org/everse/i/indicators/has_published_package"},
+    {"name": "version_control_use","plugin": "RSFC","@id": "https://w3id.org/everse/i/indicators/version_control_use"}
+  ]
+}

--- a/configurations/skao_configuration.json
+++ b/configurations/skao_configuration.json
@@ -3,5 +3,7 @@
     {"name": "software_has_documentation","plugin": "RSFC","@id": "https://w3id.org/everse/i/indicators/software_has_documentation"},
     {"name": "software_has_license", "plugin": "RSFC", "@id": "https://w3id.org/everse/i/indicators/software_has_license" },
     {"name": "requirements_specified","plugin": "RSFC","@id": "https://w3id.org/everse/i/indicators/requirements_specified"}
-  ]
+  ],
+    "comment": "Indicators for SKAO  as defined by the community perspective https://everse.software/indicators/website/community.html"
+
 }

--- a/configurations/skao_configuration.json
+++ b/configurations/skao_configuration.json
@@ -1,0 +1,7 @@
+{
+  "indicators": [
+    {"name": "software_has_documentation","plugin": "RSFC","@id": "https://w3id.org/everse/i/indicators/software_has_documentation"},
+    {"name": "software_has_license", "plugin": "RSFC", "@id": "https://w3id.org/everse/i/indicators/software_has_license" },
+    {"name": "requirements_specified","plugin": "RSFC","@id": "https://w3id.org/everse/i/indicators/requirements_specified"}
+  ]
+}


### PR DESCRIPTION
# RESQUI configurations by organization


## SKAO

| Requested requirement | Indicator | Plugin | Coverage |
|---|---|---|---|
| Software has documentation | `software_has_documentation` | RSFC | Covered |
| Software has a license | `software_has_license` | RSFC | Covered |
| Software has requirements/dependencies | `requirements_specified` | RSFC | Covered |

**Result:** the configuration covers all requested requirements.

## OSSR

| Requested requirement | Indicator | Plugin | Coverage |
|---|---|---|---|
| Descriptive metadata | `descriptive_metadata` | RSFC | Covered |
| License | `software_has_license` | RSFC | Covered |
| Releases | `has_releases` | RSFC | Covered |
| Published as a package | `has_published_package` | OpenSSFScorecard | Covered |
| Uses version control | `version_control_use` | RSFC | Covered |
| Has a container file | software_is_containerized | RSFC | *work in progress* |


## ELIXIR

| Requested requirement | Indicator | Plugin | Coverage |
|---|---|---|---|
| Analysis of common vulnerabilities | `static_analysis_common_vulnerabilities` | OpenSSFScorecard | Covered |
| Follows versioning standards | `versioning_standards_use` | RSFC | Covered |
| Has metadata | `descriptive_metadata` | RSFC | Covered |
| Has documentation | `software_has_documentation` | RSFC | Covered |
| Has a license | `software_has_license` | RSFC | Covered |
| Has sufficient test coverage | `software_test_coverage`  | — | *work in progress* |
| Archived in a scholarly registry | `archived_in_software_heritage` | RSFC | Covered  |
| Listed in a registry | `listed_in_registry` | OEBFAIR | Covered |
| Has tests | `software_has_tests` | RSFC | Covered |

## HSF

| Requested requirement | Indicator | Plugin | Coverage |
|---|---|---|---|
| Has communication channels | `has_active_communication_channels` | — | Not supported |
| Issues are addressed within a defined time frame | `response_timeframe_ok` | — | Not suported |
| Follows versioning standards | `versioning_standards_use` | RSFC | Covered |
| Has documentation | `software_has_documentation` | RSFC | Covered |
| Has a license | `software_has_license` | RSFC | Covered |
| Uses version control | `version_control_use` | RSFC | Covered |
| Has issue tracking | `support_issue_tracking` | RSFC | Not Covered|
| Provides tests | `software_has_tests` | RSFC | Covered |
| Has contribution guidelines | `has_contribution_guidelines` | RSFC | Covered |
| Has requirements | `requirements_specified` | RSFC | Covered |


Related to #86