### PR TITLE
Fix TypeError when printing OpenSSFScorecard evidence in verbose mode

### DIFF
--- a/src/resqui/plugins/openssfscorecard.py
+++ b/src/resqui/plugins/openssfscorecard.py
@@ -84,6 +84,11 @@ class OpenSSFScorecard(IndicatorPlugin):
             print(r.stdout)
             raise
 
+    def format_details(self, details):
+        if not details:
+            return "No further details provided."
+        return "\n".join(details)
+
     def get_score(self, results, check_name):
         checks = results["checks"]
         if not checks:
@@ -140,11 +145,11 @@ class OpenSSFScorecard(IndicatorPlugin):
 
         if check["score"] > 0:
             output = "true"
-            evidence = check["details"]
+            evidence = self.format_details(check["details"])
             success = True
         else:
             output = "false"
-            evidence = check["details"]
+            evidence = self.format_details(check["details"])
             success = False
 
         return CheckResult(
@@ -180,11 +185,11 @@ class OpenSSFScorecard(IndicatorPlugin):
         check = self.get_score(results, "SAST")
         if check["score"] > 0:
             output = "true"
-            evidence = check["details"]
+            evidence = self.format_details(check["details"])
             success = True
         else:
             output = "false"
-            evidence = check["details"]
+            evidence = self.format_details(check["details"])
             success = False
 
         return CheckResult(
@@ -201,11 +206,11 @@ class OpenSSFScorecard(IndicatorPlugin):
         check = self.get_score(results, "Dependency-Update-Tool")
         if check["score"] > 0:
             output = "true"
-            evidence = check["details"]
+            evidence = self.format_details(check["details"])
             success = True
         else:
             output = "false"
-            evidence = check["details"]
+            evidence = self.format_details(check["details"])
             success = False
 
         return CheckResult(
@@ -222,11 +227,11 @@ class OpenSSFScorecard(IndicatorPlugin):
         check = self.get_score(results, "Vulnerabilities")
         if check["score"] >= 7:
             output = "true"
-            evidence = check["details"]
+            evidence = self.format_details(check["details"])
             success = True
         else:
             output = "false"
-            evidence = check["details"]
+            evidence = self.format_details(check["details"])
 
         return CheckResult(
             process="Checks if there are vulnerabilities in the repository",
@@ -242,11 +247,11 @@ class OpenSSFScorecard(IndicatorPlugin):
         check = self.get_score(results, "Fuzzing")
         if check["score"] > 0:
             output = "true"
-            evidence = check["details"]
+            evidence = self.format_details(check["details"])
             success = True
         else:
             output = "false"
-            evidence = check["details"]
+            evidence = self.format_details(check["details"])
             success = False
 
         return CheckResult(
@@ -262,11 +267,11 @@ class OpenSSFScorecard(IndicatorPlugin):
         check = self.get_score(results, "Fuzzing")
         if check["score"] == 10:
             output = "true"
-            evidence = check["details"]
+            evidence = self.format_details(check["details"])
             success = True
         else:
             output = "false"
-            evidence = check["details"]
+            evidence = self.format_details(check["details"])
             success = False
 
         return CheckResult(


### PR DESCRIPTION
Fixes #99 

## Summary
- OpenSSF Scorecard's JSON output returns `details` as a list of strings, but six check methods (`has_published_package`, `dependency_management`, `uses_fuzzing`, `no_critical_vulnerability`, `static_analysis_common_vulnerabilities`, `has_no_binary_artifacts`) assigned it directly to `CheckResult.evidence`, which is typed as `str`.
- This crashed with `TypeError: can only concatenate str (not "list") to str` as soon as `resqui -v` tried to print the evidence (`cli.py` does `result.evidence + status`), aborting the whole run partway through.
- Added `OpenSSFScorecard.format_details()` to join the list into a newline-separated string (or a placeholder when empty/None), and used it at all 6 call sites.

## Test plan
- [x] `python3 -m py_compile src/resqui/plugins/openssfscorecard.py`
- [x] Reproduced the original crash by running `resqui -c configurations/practical-smp-escience-center/smp-escience-high.json -t "$GITHUB_TOKEN" -v` against this repo (hit `has_published_package/OpenSSFScorecard`)
- [ ] Re-run the same command against this branch to confirm the crash is gone (not yet re-verified end-to-end)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
https://claude.ai/code/session_012KQ4BHoo6AUDDpWa9R4Q1o

---

I believe this fix is cleaner than #100 as it fixes the root cause and not only the print.
#100 can be kept as an additional safety though