### PR TITLE
fix: update venv creation symlinks = True

### DIFF
--- a/src/resqui/executors/python.py
+++ b/src/resqui/executors/python.py
@@ -1,11 +1,11 @@
-import venv
 import os
-import tempfile
 import shutil
 import subprocess
+import tempfile
+import venv
 
-from resqui.tools import normalized
 from resqui.executors.base import ExecutorInitError
+from resqui.tools import normalized
 
 
 class PythonExecutor:
@@ -24,7 +24,7 @@ class PythonExecutor:
         self.temp_dir = tempfile.mkdtemp()
         self.environment = environment if environment is not None else {}
         try:
-            venv.create(self.temp_dir, with_pip=True)
+            venv.create(self.temp_dir, with_pip=True, symlinks=(os.name != "nt"))
             if packages is None:
                 return
             for package in packages:


### PR DESCRIPTION
update venv creation with "symlinks=True" to be compatible with uv.  Should not have issue for non uv users.

## Summary

Change the way venv are created by using symlinks. This should enable the use of resqui using uv managed project.

I use  ̀=(os.name != "nt")` instead of `=True` so it works also on Windows which does not like using symlinks.

Linked to issue #110 

## Validation

- [x] I ran `make test` locally, or I cannot run it and explained why.
- [ ] If I changed CLI behavior, configuration loading, or plugin results, I ran `resqui -c configurations/basic.json -t <token>` or explained why that was not possible.
- [ ] If I changed packaging or installation behavior, I verified `make install-dev` and `pip install .` still work.

## Review notes

- [x] This PR targets `main`.
- [ ] I updated `README.md` if I changed CLI flags, action inputs, setup steps, output semantics, or the expected configuration format.
- [ ] I updated files under `configurations/` if the default or reference indicator sets changed.
- [ ] I added or updated tests in `tests/` when behavior changed.

## Related issue

Link the issue if there is one. If there is no issue, state the maintenance problem this PR resolves.
