### PR TITLE
Fix OEBFAIR plugin under-declaring its indicators

### DIFF
--- a/src/resqui/plugins/oebfair.py
+++ b/src/resqui/plugins/oebfair.py
@@ -19,8 +19,14 @@ class OEBFAIR(IndicatorPlugin):
         "has_citation",
         "has_license",
         "has_documentation",
+        "has_releases",
         "descriptive_metadata",
-        "listed_in_registry"
+        "listed_in_registry",
+        "versioning_standards_use",
+        "version_control_use",
+        "software_has_tests",
+        "repository_workflows",
+        "archived_in_software_heritage"
     ]
 
     def __init__(self, context):


### PR DESCRIPTION
## Summary
- The `OEBFAIR` plugin's `indicators` list only advertised 7 of the 13 check methods actually implemented on the class.
- Adds the 6 missing entries: `has_releases`, `versioning_standards_use`, `version_control_use`, `software_has_tests`, `repository_workflows`, `archived_in_software_heritage`.

## Test plan
- [x] Confirm `resqui indicators` now lists all 13 OEB-FAIR indicators

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016dZjsnJsusned3iJsN4Jqw