### PR TITLE
Fix indicator @id vocabulary drift and validate against EVERSE vocabulary

### DIFF
--- a/configurations/basic.json
+++ b/configurations/basic.json
@@ -1,6 +1,6 @@
 {
   "indicators": [
-	  { "name": "has_license", "plugin": "HowFairIs", "@id": "https://w3id.org/everse/i/indicators/license" },
-	  { "name": "has_citation", "plugin": "CFFConvert", "@id": "https://w3id.org/everse/i/indicators/citation" }
+	  { "name": "has_license", "plugin": "HowFairIs", "@id": "https://w3id.org/everse/i/indicators/software_has_license" },
+	  { "name": "has_citation", "plugin": "CFFConvert", "@id": "https://w3id.org/everse/i/indicators/software_has_citation" }
   ]
 }

--- a/configurations/indicators_rs_infrastructure.json
+++ b/configurations/indicators_rs_infrastructure.json
@@ -3,7 +3,7 @@
       { "name": "archived_in_software_heritage", "plugin": "RSFC", "@id": "https://w3id.org/everse/i/indicators/archived_in_software_heritage" },
       { "name": "descriptive_metadata", "plugin": "RSFC", "@id": "https://w3id.org/everse/i/indicators/descriptive_metadata" },
       { "name": "software_has_citation", "plugin": "RSFC", "@id": "https://w3id.org/everse/i/indicators/software_has_citation" },
-      { "name": "has_ci_tests", "plugin": "OpenSSFScorecard", "@id": "https://w3id.org/everse/i/indicators/software_has_ci-tests" },
+      { "name": "has_ci_tests", "plugin": "OpenSSFScorecard", "@id": "https://w3id.org/everse/i/indicators/has_ci-tests" },
       { "name": "software_has_license", "plugin": "RSFC", "@id": "https://w3id.org/everse/i/indicators/software_has_license" },
       { "name": "has_published_package", "plugin": "OpenSSFScorecard", "@id": "https://w3id.org/everse/i/indicators/has_published_package" },
       { "name": "has_releases", "plugin": "RSFC", "@id": "https://w3id.org/everse/i/indicators/has_releases" },

--- a/docs/explanation/indicators.md
+++ b/docs/explanation/indicators.md
@@ -11,7 +11,7 @@ Looks for a file named `LICENSE` or `LICENSE.md` in the repository root using
 the [howfairis](https://github.com/fair-software/howfairis) library. Requires a
 GitHub token.
 
-W3ID: `https://w3id.org/everse/i/indicators/license`
+W3ID: `https://w3id.org/everse/i/indicators/software_has_license`
 
 ### `has_citation` — CFFConvert
 
@@ -19,7 +19,7 @@ Checks for a valid `CITATION.cff` file using
 [cffconvert](https://github.com/citation-file-format/cffconvert). Both
 presence and schema validity are verified.
 
-W3ID: `https://w3id.org/everse/i/indicators/citation`
+W3ID: `https://w3id.org/everse/i/indicators/software_has_citation`
 
 ### `has_ci_tests` — OpenSSFScorecard
 

--- a/docs/how-to/custom-configuration.md
+++ b/docs/how-to/custom-configuration.md
@@ -11,12 +11,12 @@ lets you choose exactly which indicators to run and which plugins to use.
     {
       "name": "has_license",
       "plugin": "HowFairIs",
-      "@id": "https://w3id.org/everse/i/indicators/license"
+      "@id": "https://w3id.org/everse/i/indicators/software_has_license"
     },
     {
       "name": "has_citation",
       "plugin": "CFFConvert",
-      "@id": "https://w3id.org/everse/i/indicators/citation"
+      "@id": "https://w3id.org/everse/i/indicators/software_has_citation"
     }
   ]
 }

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -42,12 +42,12 @@ When no `-c` flag is provided, resqui uses this built-in configuration:
     {
       "name": "has_license",
       "plugin": "HowFairIs",
-      "@id": "https://w3id.org/everse/i/indicators/license"
+      "@id": "https://w3id.org/everse/i/indicators/software_has_license"
     },
     {
       "name": "has_citation",
       "plugin": "CFFConvert",
-      "@id": "https://w3id.org/everse/i/indicators/citation"
+      "@id": "https://w3id.org/everse/i/indicators/software_has_citation"
     },
     {
       "name": "has_ci_tests",

--- a/docs/tutorials/first-assessment.md
+++ b/docs/tutorials/first-assessment.md
@@ -55,7 +55,7 @@ Open `resqui_summary.json`. Each entry in `checks` corresponds to one indicator:
 ```json
 {
   "@type": "CheckResult",
-  "assessesIndicator": { "@id": "https://w3id.org/everse/i/indicators/license" },
+  "assessesIndicator": { "@id": "https://w3id.org/everse/i/indicators/software_has_license" },
   "checkingSoftware": { "name": "HowFairIs", "version": "0.14.2" },
   "evidence": "Found license file: 'LICENSE'.",
   "output": "valid",

--- a/src/resqui/config.py
+++ b/src/resqui/config.py
@@ -1,16 +1,18 @@
 import json
 
+from resqui.vocabulary import is_known_indicator_id
+
 DEFAULT_CONFIG = {
     "indicators": [
         {
             "name": "has_license",
             "plugin": "HowFairIs",
-            "@id": "https://w3id.org/everse/i/indicators/license",
+            "@id": "https://w3id.org/everse/i/indicators/software_has_license",
         },
         {
             "name": "has_citation",
             "plugin": "CFFConvert",
-            "@id": "https://w3id.org/everse/i/indicators/citation",
+            "@id": "https://w3id.org/everse/i/indicators/software_has_citation",
         },
         {"name": "has_ci_tests", "plugin": "OpenSSFScorecard", "@id": "missing"},
         {
@@ -41,3 +43,14 @@ class Configuration:
             print(f"Loading configuration from '{filepath}'.")
             with open(filepath) as f:
                 self._cfg = json.load(f)
+
+        self._warn_about_unknown_ids()
+
+    def _warn_about_unknown_ids(self):
+        for indicator in self._cfg.get("indicators", []):
+            indicator_id = indicator.get("@id")
+            if not is_known_indicator_id(indicator_id):
+                print(
+                    f"Warning: indicator '{indicator.get('name')}' has an @id "
+                    f"not found in the EVERSE indicator vocabulary: '{indicator_id}'"
+                )

--- a/src/resqui/vocabulary.py
+++ b/src/resqui/vocabulary.py
@@ -1,0 +1,70 @@
+"""Canonical EVERSE indicator vocabulary.
+
+Source: https://everse.software/indicators/api/indicators.json
+"""
+
+INDICATOR_BASE_URI = "https://w3id.org/everse/i/indicators/"
+
+MISSING_ID = "missing"
+
+INDICATOR_SLUGS = frozenset(
+    {
+        "passed_tests_ok",
+        "code_churn_ok",
+        "code_duplication_ok",
+        "code_smells_ok",
+        "codemeta_completeness",
+        "internal_cohesion_ok",
+        "coupling_between_objects_ok",
+        "cyclomatic_complexity_ok",
+        "functional_correctness",
+        "static_analysis_common_vulnerabilities",
+        "maintainability_index_ok",
+        "no_critical_vulnerability",
+        "no_leaked_credentials",
+        "lines_of_code_ok",
+        "has_active_communication_channels",
+        "has_active_contributors",
+        "has_no_binary_artifacts",
+        "project_is_active",
+        "response_timeframe_ok",
+        "versioning_standards_use",
+        "repository_workflows",
+        "has_ci-tests",
+        "dependency_management",
+        "descriptive_metadata",
+        "software_has_documentation",
+        "software_has_license",
+        "has_no_linting_issues",
+        "persistent_and_unique_identifier",
+        "has_releases",
+        "software_test_coverage",
+        "metadata_is_up_to_date",
+        "archived_in_software_heritage",
+        "archived_in_scholarly_repository",
+        "listed_in_registry",
+        "has_published_package",
+        "version_control_use",
+        "support_issue_tracking",
+        "software_has_tests",
+        "has_contribution_guidelines",
+        "human_code_review_requirement",
+        "requirements_specified",
+        "uses_tool_for_warnings_and_mistakes",
+        "software_has_license_for_file_types",
+        "software_has_citation",
+        "uses_fuzzing",
+        "code_documentation_coverage_ok",
+        "software_is_containerized",
+    }
+)
+
+KNOWN_INDICATOR_IDS = frozenset(INDICATOR_BASE_URI + slug for slug in INDICATOR_SLUGS)
+
+
+def is_known_indicator_id(indicator_id):
+    """
+    Whether `indicator_id` is either the "missing" sentinel or a W3ID URI
+    listed in the EVERSE indicator vocabulary.
+    """
+    return indicator_id == MISSING_ID or indicator_id in KNOWN_INDICATOR_IDS

--- a/src/resqui/vocabulary.py
+++ b/src/resqui/vocabulary.py
@@ -1,70 +1,40 @@
-"""Canonical EVERSE indicator vocabulary.
+"""Lookup of the canonical EVERSE indicator vocabulary."""
 
-Source: https://everse.software/indicators/api/indicators.json
-"""
+import requests
 
-INDICATOR_BASE_URI = "https://w3id.org/everse/i/indicators/"
-
+VOCABULARY_URL = "https://everse.software/indicators/api/indicators.json"
 MISSING_ID = "missing"
 
-INDICATOR_SLUGS = frozenset(
-    {
-        "passed_tests_ok",
-        "code_churn_ok",
-        "code_duplication_ok",
-        "code_smells_ok",
-        "codemeta_completeness",
-        "internal_cohesion_ok",
-        "coupling_between_objects_ok",
-        "cyclomatic_complexity_ok",
-        "functional_correctness",
-        "static_analysis_common_vulnerabilities",
-        "maintainability_index_ok",
-        "no_critical_vulnerability",
-        "no_leaked_credentials",
-        "lines_of_code_ok",
-        "has_active_communication_channels",
-        "has_active_contributors",
-        "has_no_binary_artifacts",
-        "project_is_active",
-        "response_timeframe_ok",
-        "versioning_standards_use",
-        "repository_workflows",
-        "has_ci-tests",
-        "dependency_management",
-        "descriptive_metadata",
-        "software_has_documentation",
-        "software_has_license",
-        "has_no_linting_issues",
-        "persistent_and_unique_identifier",
-        "has_releases",
-        "software_test_coverage",
-        "metadata_is_up_to_date",
-        "archived_in_software_heritage",
-        "archived_in_scholarly_repository",
-        "listed_in_registry",
-        "has_published_package",
-        "version_control_use",
-        "support_issue_tracking",
-        "software_has_tests",
-        "has_contribution_guidelines",
-        "human_code_review_requirement",
-        "requirements_specified",
-        "uses_tool_for_warnings_and_mistakes",
-        "software_has_license_for_file_types",
-        "software_has_citation",
-        "uses_fuzzing",
-        "code_documentation_coverage_ok",
-        "software_is_containerized",
-    }
-)
+_known_ids_cache = None
 
-KNOWN_INDICATOR_IDS = frozenset(INDICATOR_BASE_URI + slug for slug in INDICATOR_SLUGS)
+
+def fetch_known_indicator_ids():
+    """
+    Fetches the set of canonical indicator @id URIs from the EVERSE
+    indicator vocabulary API. The result is cached for the lifetime of
+    the process.
+    """
+    global _known_ids_cache
+    if _known_ids_cache is None:
+        response = requests.get(VOCABULARY_URL, timeout=10)
+        response.raise_for_status()
+        _known_ids_cache = frozenset(
+            indicator["@id"] for indicator in response.json()["indicators"]
+        )
+    return _known_ids_cache
 
 
 def is_known_indicator_id(indicator_id):
     """
     Whether `indicator_id` is either the "missing" sentinel or a W3ID URI
-    listed in the EVERSE indicator vocabulary.
+    listed in the EVERSE indicator vocabulary. If the vocabulary can't be
+    fetched (e.g. no network access), validation is skipped and the id is
+    treated as known so resqui remains usable offline.
     """
-    return indicator_id == MISSING_ID or indicator_id in KNOWN_INDICATOR_IDS
+    if indicator_id == MISSING_ID:
+        return True
+    try:
+        known_ids = fetch_known_indicator_ids()
+    except requests.RequestException:
+        return True
+    return indicator_id in known_ids

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -49,3 +49,76 @@ class TestConfigurationFromFile(unittest.TestCase):
         with patch("builtins.print"):
             cfg = Configuration(filepath=path)
         self.assertEqual(cfg._cfg["indicators"], [])
+
+
+class TestConfigurationVocabularyValidation(unittest.TestCase):
+    def _write_config(self, data):
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            json.dump(data, f)
+            return f.name
+
+    def test_warns_on_unknown_id(self):
+        custom = {
+            "indicators": [
+                {
+                    "name": "has_license",
+                    "plugin": "HowFairIs",
+                    "@id": "https://w3id.org/everse/i/indicators/license",
+                }
+            ]
+        }
+        path = self._write_config(custom)
+        with patch("builtins.print") as mock_print:
+            Configuration(filepath=path)
+        warnings = [
+            call.args[0]
+            for call in mock_print.call_args_list
+            if call.args and "Warning" in call.args[0]
+        ]
+        self.assertTrue(
+            any("has_license" in w and "license" in w for w in warnings)
+        )
+
+    def test_no_warning_for_known_id(self):
+        custom = {
+            "indicators": [
+                {
+                    "name": "has_license",
+                    "plugin": "HowFairIs",
+                    "@id": "https://w3id.org/everse/i/indicators/software_has_license",
+                }
+            ]
+        }
+        path = self._write_config(custom)
+        with patch("builtins.print") as mock_print:
+            Configuration(filepath=path)
+        warnings = [
+            call.args[0]
+            for call in mock_print.call_args_list
+            if call.args and "Warning" in call.args[0]
+        ]
+        self.assertEqual(warnings, [])
+
+    def test_no_warning_for_missing_sentinel(self):
+        custom = {
+            "indicators": [{"name": "has_ci_tests", "plugin": "X", "@id": "missing"}]
+        }
+        path = self._write_config(custom)
+        with patch("builtins.print") as mock_print:
+            Configuration(filepath=path)
+        warnings = [
+            call.args[0]
+            for call in mock_print.call_args_list
+            if call.args and "Warning" in call.args[0]
+        ]
+        self.assertEqual(warnings, [])
+
+    def test_default_config_has_no_vocabulary_warnings(self):
+        with patch("builtins.print") as mock_print:
+            Configuration()
+        warnings = [
+            call.args[0]
+            for call in mock_print.call_args_list
+            if call.args and "Warning" in call.args[0]
+        ]
+        self.assertEqual(warnings, [])

--- a/tests/test_vocabulary.py
+++ b/tests/test_vocabulary.py
@@ -1,0 +1,48 @@
+import unittest
+
+from resqui.vocabulary import fetch_known_indicator_ids, is_known_indicator_id
+
+
+class TestVocabulary(unittest.TestCase):
+    def test_fetches_known_ids_from_everse_api(self):
+        known_ids = fetch_known_indicator_ids()
+        self.assertIsInstance(known_ids, frozenset)
+        self.assertGreater(len(known_ids), 0)
+        self.assertTrue(
+            all(
+                uid.startswith("https://w3id.org/everse/i/indicators/")
+                for uid in known_ids
+            )
+        )
+
+    def test_missing_sentinel_is_always_known(self):
+        self.assertTrue(is_known_indicator_id("missing"))
+
+    def test_known_id_from_vocabulary(self):
+        known_ids = fetch_known_indicator_ids()
+        sample_id = next(iter(known_ids))
+        self.assertTrue(is_known_indicator_id(sample_id))
+
+    def test_unknown_id_is_rejected(self):
+        self.assertFalse(
+            is_known_indicator_id("https://w3id.org/everse/i/indicators/citation")
+        )
+
+    def test_known_license_and_citation_ids(self):
+        self.assertTrue(
+            is_known_indicator_id(
+                "https://w3id.org/everse/i/indicators/software_has_license"
+            )
+        )
+        self.assertTrue(
+            is_known_indicator_id(
+                "https://w3id.org/everse/i/indicators/software_has_citation"
+            )
+        )
+        self.assertTrue(
+            is_known_indicator_id("https://w3id.org/everse/i/indicators/has_ci-tests")
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- `basic.json` used `indicators/license` and `indicators/citation`; every other config uses the canonical `software_has_license` / `software_has_citation`. Fixed.
- `indicators_rs_infrastructure.json` used `software_has_ci-tests`, which isn't a real vocabulary term — confirmed against https://everse.software/indicators/api/indicators.json that the correct id is `has_ci-tests` (matching what `complete.json` already had).
- The same `license`/`citation` drift was baked into `DEFAULT_CONFIG` in `src/resqui/config.py` and mirrored across the docs — fixed both.
- Added `src/resqui/vocabulary.py`, which fetches the canonical indicator list live from https://everse.software/indicators/api/indicators.json (cached per process, falls back to permissive if offline) instead of bundling a static copy that would drift again as new indicators are published. `Configuration` now prints a non-fatal warning for any `@id` that is neither `"missing"` nor a recognized vocabulary URI.

## Test plan
- [x] `python -m pytest tests/` — all passing except two pre-existing, unrelated Docker-dependent failures
- [x] All tracked `configurations/*.json` files checked programmatically against the live vocabulary — no remaining drift
- [x] `tests/test_vocabulary.py` exercises the live fetch against the real EVERSE API
- [x] `tests/test_config.py` covers: unknown `@id` warns, known `@id` is silent, `"missing"` sentinel is silent, default config produces no warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016dZjsnJsusned3iJsN4Jqw