### PR TITLE
Remove dead has_citation from OEBFAIR plugin

### DIFF
--- a/configurations/complete.json
+++ b/configurations/complete.json
@@ -21,11 +21,6 @@
       "@id": "https://w3id.org/everse/i/indicators/descriptive_metadata"
     },
     {
-      "name": "has_citation",
-      "plugin": "OEBFAIR",
-      "@id": "https://w3id.org/everse/i/indicators/software_has_citation"
-    },
-    {
       "name": "has_documentation",
       "plugin": "OEBFAIR",
       "@id": "https://w3id.org/everse/i/indicators/software_has_documentation"

--- a/src/resqui/plugins/oebfair.py
+++ b/src/resqui/plugins/oebfair.py
@@ -16,7 +16,6 @@ class OEBFAIR(IndicatorPlugin):
     indicators = [
         "unique_identifier",
         "has_package",
-        "has_citation",
         "has_license",
         "has_documentation",
         "has_releases",
@@ -290,30 +289,6 @@ class OEBFAIR(IndicatorPlugin):
 
         for check in checks:
             if "software_tests" in check["assessesIndicator"]["@id"]:
-                if check["output"] == "true":
-                    success = True
-                else:
-                    success = False
-
-                check_res = CheckResult(
-                    process=check["process"],
-                    status_id=check["status"]["@id"],
-                    output=check["output"],
-                    evidence=check["evidence"],
-                    success=success,
-                )
-
-                check_list.append(check_res)
-
-        return check_list
-
-    def has_citation(self, url, branch_hash_or_tag):
-        report = self.execute(url, branch_hash_or_tag)
-        checks = report["checks"]
-        check_list = []
-
-        for check in checks:
-            if "software_has_citation" in check["assessesIndicator"]["@id"]:
                 if check["output"] == "true":
                     success = True
                 else:


### PR DESCRIPTION
## Summary
- `has_citation` was never actually invoked in `resqui-oeb-plugin`'s `fair2everse()` (the call is commented out), so this indicator's `check_list` was always empty when run through OEBFAIR — silently reporting no coverage instead of surfacing an error.
- Removes the dead `has_citation()` method and its entry from `OEBFAIR.indicators`, and removes the corresponding `{"name": "has_citation", "plugin": "OEBFAIR", ...}` entry from `configurations/complete.json` (leaving it would make the CLI crash with `AttributeError`, since indicators are dispatched via `getattr(plugin_instance, name)`).
- `software_has_citation` is still evaluated via the `CFFConvert` and `RSFC` plugins, which are unaffected.

## Test plan
- [x] `python3 -m py_compile src/resqui/plugins/oebfair.py`
- [x] `configurations/complete.json` still parses as valid JSON

Fixes #118

@redmitry can you review please ?
