### PR TITLE
doc: explicit the usage when -u argument is not provided,

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Usage:
     resqui indicators
 
 Options:
-    -u <repository_url>   URL of the repository to be analyzed (GitHub URLs, Zenodo DOIs and URLs accepted)
+    -u <repository_url>   URL of the repository to be analyzed (GitHub URLs, Zenodo DOIs and URLs accepted). If omitted, resqui reads the remote repository URL from the current working directory's `.git` metadata.
     -c <config_file>      Path to the configuration file.
     -o <output_file>      Path to the output file [default: resqui_summary.json].
     -t <github_token>     GitHub API token.

--- a/docs/index.md
+++ b/docs/index.md
@@ -18,7 +18,7 @@ pip install resqui
 
 ## Quick start
 
-Run against the current repository using the default indicator set:
+Run from inside a Git working tree using the default indicator set. resqui reads the remote repository URL from the current working directory's `.git` metadata:
 
 ```bash
 resqui -t $GITHUB_TOKEN

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -11,7 +11,7 @@ resqui indicators
 
 | Flag | Argument | Default | Description |
 |---|---|---|---|
-| `-u` | `<repository_url>` | current repo | URL of the repository to assess. If omitted, resqui uses the remote URL of the current working directory. |
+| `-u` | `<repository_url>` | current repo | URL of the repository to assess. If omitted, resqui reads the remote repository URL from the current working directory's `.git` metadata. |
 | `-c` | `<config_file>` | built-in default | Path to a JSON configuration file. |
 | `-o` | `<output_file>` | `resqui_summary.json` | Path for the JSON-LD output report. |
 | `-t` | `<github_token>` | — | GitHub personal access token. Required by `HowFairIs` and `OpenSSFScorecard`. |

--- a/docs/tutorials/first-assessment.md
+++ b/docs/tutorials/first-assessment.md
@@ -30,7 +30,7 @@ Navigate to any Git repository on your machine and run:
 resqui -t $GITHUB_TOKEN
 ```
 
-resqui detects the remote URL automatically and runs all default indicators.
+resqui detects the repository remote URL automatically from the current working directory's `.git` metadata and runs all default indicators.
 You will see a live progress line per indicator:
 
 ```


### PR DESCRIPTION
 run on local project looking for .git to find a proper git repo url.

## Summary

Describe the change in terms of `resqui`, the composite action in `action.yml`, a configuration under `configurations/`, or a plugin/executor under `src/resqui/`.

## Validation

- [x] I ran `make test` locally, or I cannot run it and explained why.

## Review notes

- [x] This PR targets `main`.
- [x] I updated `README.md` if I changed CLI flags, action inputs, setup steps, output semantics, or the expected configuration format.

## Related issue

Link the issue if there is one. If there is no issue, state the maintenance problem this PR resolves.
