### PR TITLE
Local run resqui

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,8 @@ Usage:
     resqui indicators
 
 Options:
-    -u <repository_url>   URL of the repository to be analyzed (GitHub URLs, Zenodo DOIs and URLs accepted)
+    -u <repository_url>   URL of the repository to be analyzed (GitHub URLs, Zenodo DOIs and URLs accepted). Mutually exclusive with -p.
+    -p <project_path>     Path to a local project directory to be analyzed without requiring Git history. Mutually exclusive with -u.
     -c <config_file>      Path to the configuration file.
     -o <output_file>      Path to the output file [default: resqui_summary.json].
     -t <github_token>     GitHub API token.
@@ -51,6 +52,8 @@ Options:
     --version             Show the version of the script.
     --help                Show this help message.
  ```
+
+Note: `-u` and `-p` are mutually exclusive. Specify either a repository URL or a local project path, not both.
 
 
 2) The GitHub Action to include in CI/CDs pipeline is available in [this repository](https://github.com/EVERSE-ResearchSoftware/resqui-github-action).

--- a/docs/index.md
+++ b/docs/index.md
@@ -30,6 +30,12 @@ Run against a remote repository and write output to a custom file:
 resqui -u https://github.com/org/repo -t $GITHUB_TOKEN -o report.json
 ```
 
+Run against a local project directory without requiring Git history:
+
+```bash
+resqui -p /path/to/project -t $GITHUB_TOKEN -o report.json
+```
+
 ## Navigation
 
 | Section | What you'll find |

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -11,7 +11,8 @@ resqui indicators
 
 | Flag | Argument | Default | Description |
 |---|---|---|---|
-| `-u` | `<repository_url>` | current repo | URL of the repository to assess. If omitted, resqui uses the remote URL of the current working directory. |
+| `-u` | `<repository_url>` | current repo | URL of the repository to assess. If omitted, resqui uses the remote URL of the current working directory. Mutually exclusive with `-p`. |
+| `-p` | `<project_path>` | — | Path to a local project directory to be analyzed without requiring Git history. Mutually exclusive with `-u`. |
 | `-c` | `<config_file>` | built-in default | Path to a JSON configuration file. |
 | `-o` | `<output_file>` | `resqui_summary.json` | Path for the JSON-LD output report. |
 | `-t` | `<github_token>` | — | GitHub personal access token. Required by `HowFairIs` and `OpenSSFScorecard`. |
@@ -20,6 +21,8 @@ resqui indicators
 | `-v` | — | off | Verbose output: prints full evidence text for each indicator. |
 | `--version` | — | — | Print the installed version and exit. |
 | `--help` | — | — | Print usage and exit. |
+
+> Note: `-u` and `-p` are mutually exclusive. Specify either a repository URL or a local project path, not both.
 
 ## Subcommands
 

--- a/docs/tutorials/first-assessment.md
+++ b/docs/tutorials/first-assessment.md
@@ -75,6 +75,12 @@ You can point resqui at any public repository without cloning it yourself:
 resqui -u https://github.com/org/other-project -t $GITHUB_TOKEN -o other-report.json
 ```
 
+Alternatively, you can assess a local project directory directly by passing `-p` instead of `-u`:
+
+```bash
+resqui -p /path/to/project -t $GITHUB_TOKEN -o other-report.json
+```
+
 ## Next steps
 
 - [Write a custom configuration](../how-to/custom-configuration.md) to choose which indicators to run

--- a/src/resqui/cli.py
+++ b/src/resqui/cli.py
@@ -5,6 +5,7 @@ Usage:
 
 Options:
     -u <repository_url>   URL of the repository to be analyzed (GitHub URLs, Zenodo DOIs and URLs accepted).
+    -p <project_path>     Path to a local project directory to be analyzed without requiring Git history.
     -c <config_file>      Path to the configuration file.
     -o <output_file>      Path to the output file [default: resqui_summary.json].
     -t <github_token>     GitHub API token.
@@ -15,29 +16,29 @@ Options:
     --help                Show this help message.
 """
 
-import itertools
-import time
-import threading
 import importlib
+import itertools
 import os
 import shutil
 import subprocess
 import sys
 import tempfile
+import threading
+import time
 
-from resqui.core import Context, Summary
 from resqui.config import Configuration
+from resqui.core import Context, Summary
+from resqui.docopt import docopt
+from resqui.executors import ExecutorInitError
+from resqui.plugins import IndicatorPlugin, PluginInitError
 from resqui.tools import (
+    ensure_list,
     indented,
     is_zenodo_url,
-    to_https,
     project_name_from_url,
-    ensure_list,
+    to_https,
     zenodo_url_to_git,
 )
-from resqui.plugins import IndicatorPlugin, PluginInitError
-from resqui.executors import ExecutorInitError
-from resqui.docopt import docopt
 from resqui.version import __version__
 
 
@@ -137,19 +138,46 @@ def resqui():
     configuration = Configuration(args["-c"])
     output_file = args["-o"]
     url = args["-u"]
+    project_path = args["-p"]
     branch = args["-b"]
     github_token = args["-t"]
     dashverse_token = args["-d"]
     verbose = args["-v"]
 
     temp_dir = None
-    if url is None:
+    local_path = None
+    if project_path is not None:
+        if url is not None:
+            print("Error: -u and -p are mutually exclusive.")
+            exit(1)
+        local_path = os.path.abspath(os.path.expanduser(os.path.expandvars(project_path)))
+        if not os.path.isdir(local_path):
+            print(
+                f"Error: Project path does not exist or is not a directory: {local_path}"
+            )
+            exit(1)
+        url = local_path
+        project_name = os.path.basename(local_path.rstrip(os.sep)) or local_path
+        author = "local"
+        email = "local"
+        software_version = "local"
+        branch_hash_or_tag = branch if branch is not None else "local"
+    elif url is None:
         gitinspector = GitInspector()
         if not gitinspector.is_a_git_repository:
             print(
                 "Error: Not a Git repository. Either run resqui from within a repository or specify one with -u <url>"
             )
             exit(1)
+
+        url = gitinspector.remote_https_url
+        project_name = gitinspector.project_name_from_url
+        author = gitinspector.author
+        email = gitinspector.email
+        software_version = gitinspector.version
+        branch_hash_or_tag = (
+            gitinspector.current_commit_hash if branch is None else branch
+        )
     else:
         if is_zenodo_url(url):
             url, branch = zenodo_url_to_git(url)
@@ -167,13 +195,14 @@ def resqui():
             raise
         gitinspector = GitInspector(temp_dir)
 
-    url = gitinspector.remote_https_url
-    project_name = gitinspector.project_name_from_url
-    author = gitinspector.author
-    email = gitinspector.email
-    software_version = gitinspector.version
-
-    branch_hash_or_tag = gitinspector.current_commit_hash if branch is None else branch
+        url = gitinspector.remote_https_url
+        project_name = gitinspector.project_name_from_url
+        author = gitinspector.author
+        email = gitinspector.email
+        software_version = gitinspector.version
+        branch_hash_or_tag = (
+            gitinspector.current_commit_hash if branch is None else branch
+        )
 
     if temp_dir is not None:
         shutil.rmtree(temp_dir)
@@ -183,9 +212,16 @@ def resqui():
     else:
         print("GitHub API token \033[91m✖\033[0m")
 
-    context = Context(github_token=github_token, dashverse_token=dashverse_token)
+    context = Context(
+        github_token=github_token,
+        dashverse_token=dashverse_token,
+        local_path=local_path,
+    )
 
-    print(f"Repository URL: {url}")
+    if local_path is not None:
+        print(f"Project path: {local_path}")
+    else:
+        print(f"Repository URL: {url}")
     print(f"Project name: {project_name}")
     print(f"Author: {author}")
     print(f"Email: {email}")
@@ -210,6 +246,13 @@ def resqui():
         if plugin_class_name not in plugin_instances:
             plugin_module = importlib.import_module(base_package + ".plugins")
             plugin_class = getattr(plugin_module, plugin_class_name)
+            if context.local_path is not None and not getattr(
+                plugin_class, "supports_local_path", False
+            ):
+                print(
+                    f"⚠️  {plugin_class_name} does not support local project path mode (skipping its indicators)"
+                )
+                continue
             with Spinner(print_time=False):
                 try:
                     plugin_instances[plugin_class_name] = plugin_class(context)

--- a/src/resqui/core.py
+++ b/src/resqui/core.py
@@ -1,8 +1,7 @@
 #!/usr/bin/env python3
-from datetime import datetime
-from dataclasses import dataclass
-from typing import Optional
 import json
+from dataclasses import dataclass
+from datetime import datetime
 
 from resqui.api import APIClient
 
@@ -11,8 +10,9 @@ from resqui.api import APIClient
 class Context:
     """A basic context to hold"""
 
-    github_token: Optional[str] = None
-    dashverse_token: Optional[str] = None
+    github_token: str | None = None
+    dashverse_token: str | None = None
+    local_path: str | None = None
 
 
 @dataclass

--- a/src/resqui/core.py
+++ b/src/resqui/core.py
@@ -2,6 +2,7 @@
 import json
 from dataclasses import dataclass
 from datetime import datetime
+from typing import Optional
 
 from resqui.api import APIClient
 
@@ -10,9 +11,9 @@ from resqui.api import APIClient
 class Context:
     """A basic context to hold"""
 
-    github_token: str | None = None
-    dashverse_token: str | None = None
-    local_path: str | None = None
+    github_token: Optional[str] = None
+    dashverse_token: Optional[str] = None
+    local_path: Optional[str] = None
 
 
 @dataclass

--- a/src/resqui/plugins/base.py
+++ b/src/resqui/plugins/base.py
@@ -1,8 +1,6 @@
 class PluginInitError(Exception):
     """Thrown if the initialisation of a plugin fails (e.g. missing GITHUB token)"""
 
-    pass
-
 
 class IndicatorPlugin:
     """Skeleton for an Indicator Plugin"""
@@ -11,3 +9,4 @@ class IndicatorPlugin:
     version = None
     id = None
     indicators = []
+    supports_local_path = False

--- a/src/resqui/plugins/cffconvert.py
+++ b/src/resqui/plugins/cffconvert.py
@@ -1,7 +1,7 @@
-from resqui.plugins.base import IndicatorPlugin
-from resqui.executors import PythonExecutor
 from resqui.core import CheckResult
-from resqui.tools import normalized, construct_full_url
+from resqui.executors import PythonExecutor
+from resqui.plugins.base import IndicatorPlugin
+from resqui.tools import construct_full_url, normalized
 
 
 class CFFConvert(IndicatorPlugin):
@@ -9,6 +9,7 @@ class CFFConvert(IndicatorPlugin):
     version = "2.0.0"
     python_package_name = "cffconvert"
     id = "https://w3id.org/everse/tools/cffconvert"
+    supports_local_path = False
     indicators = ["has_citation"]
 
     def __init__(self, context):

--- a/src/resqui/plugins/gitleaks.py
+++ b/src/resqui/plugins/gitleaks.py
@@ -1,10 +1,10 @@
 import json
-import subprocess
 import os
+import subprocess
 
-from resqui.plugins.base import IndicatorPlugin
-from resqui.executors import DockerExecutor
 from resqui.core import CheckResult
+from resqui.executors import DockerExecutor
+from resqui.plugins.base import IndicatorPlugin
 from resqui.workspace import create_workspace
 
 
@@ -13,6 +13,7 @@ class Gitleaks(IndicatorPlugin):
     version = "8.24.2"
     image_url = f"ghcr.io/gitleaks/gitleaks:v{version}"
     id = "https://w3id.org/everse/tools/gitleaks"
+    supports_local_path = False
     indicators = ["has_no_security_leak"]
 
     def __init__(self, context):
@@ -21,7 +22,6 @@ class Gitleaks(IndicatorPlugin):
 
     def has_no_security_leak(self, url, branch_hash_or_tag):
         report_fname = "report.json"
-
 
         with create_workspace(prefix="resqui-gitleaks-") as workspace:
             try:
@@ -37,9 +37,9 @@ class Gitleaks(IndicatorPlugin):
 
             plugin_path = workspace.container_path("/path")
             report_path = f"{plugin_path}/{report_fname}"
-            
+
             run_args = ["--rm", *workspace.docker_mount_args("/path")]
-            
+
             p = self.executor.run(
                 ["git", plugin_path, "-r", report_path], run_args=run_args
             )

--- a/src/resqui/plugins/howfairis.py
+++ b/src/resqui/plugins/howfairis.py
@@ -1,6 +1,6 @@
-from resqui.plugins.base import IndicatorPlugin, PluginInitError
-from resqui.executors import PythonExecutor
 from resqui.core import CheckResult
+from resqui.executors import PythonExecutor
+from resqui.plugins.base import IndicatorPlugin, PluginInitError
 from resqui.tools import normalized
 
 
@@ -9,6 +9,7 @@ class HowFairIs(IndicatorPlugin):
     version = "0.14.2"
     python_package_name = "howfairis"
     id = "https://w3id.org/everse/tools/howfairis"
+    supports_local_path = False
     indicators = ["has_license"]
 
     def __init__(self, context):

--- a/src/resqui/plugins/oebfair.py
+++ b/src/resqui/plugins/oebfair.py
@@ -1,18 +1,19 @@
 import json
-import tempfile
 import os
 import shutil
+import tempfile
 
-from resqui.plugins.base import IndicatorPlugin
-from resqui.executors import DockerExecutor
 from resqui.core import CheckResult
+from resqui.executors import DockerExecutor
+from resqui.plugins.base import IndicatorPlugin
 
 
 class OEBFAIR(IndicatorPlugin):
     name = "OEBFAIR"
     id = "https://w3id.org/everse/tools/fairsoft-evaluator"
     version = "0.2.2"
-    image_url = f"registry.gitlab.bsc.es/everse/resqui-oeb-plugin/resqui-oebfair:v0.2.2"
+    image_url = "registry.gitlab.bsc.es/everse/resqui-oeb-plugin/resqui-oebfair:v0.2.2"
+    supports_local_path = False
     indicators = [
         "unique_identifier",
         "has_package",
@@ -26,7 +27,7 @@ class OEBFAIR(IndicatorPlugin):
         "version_control_use",
         "software_has_tests",
         "repository_workflows",
-        "archived_in_software_heritage"
+        "archived_in_software_heritage",
     ]
 
     def __init__(self, context):
@@ -43,13 +44,11 @@ class OEBFAIR(IndicatorPlugin):
 
         url = url.removesuffix(".git")
 
-        run_args = [
-            "--rm",
-            "-v",
-            f"{tempdir}:/oebfair/oebfair_output"
-        ]
+        run_args = ["--rm", "-v", f"{tempdir}:/oebfair/oebfair_output"]
 
-        _ = self.executor.run(["--repo", url, "-t", f"{self.context.github_token}"], run_args=run_args)
+        _ = self.executor.run(
+            ["--repo", url, "-t", f"{self.context.github_token}"], run_args=run_args
+        )
 
         assessment_filename = "oebfair_assessment.json"
         assessment_fpath = os.path.join(tempdir, assessment_filename)
@@ -107,7 +106,7 @@ class OEBFAIR(IndicatorPlugin):
                     status_id=check["status"]["@id"],
                     output=check["output"],
                     evidence=check["evidence"],
-                    success=success
+                    success=success,
                 )
 
                 check_list.append(check_res)

--- a/src/resqui/plugins/openssfscorecard.py
+++ b/src/resqui/plugins/openssfscorecard.py
@@ -1,13 +1,15 @@
 import json
 import subprocess
-from resqui.plugins.base import IndicatorPlugin, PluginInitError
+
 from resqui.core import CheckResult
+from resqui.plugins.base import IndicatorPlugin, PluginInitError
 
 
 class OpenSSFScorecard(IndicatorPlugin):
     name = "OpenSSF Scorecard"
     id = "https://github.com/ossf/scorecard"
     version = "v5.4.0"
+    supports_local_path = False
     indicators = [
         "has_ci_tests",
         "human_code_review_requirement",
@@ -17,7 +19,7 @@ class OpenSSFScorecard(IndicatorPlugin):
         "no_critical_vulnerability",
         "static_analysis_common_vulnerabilities",
         "project_is_active",
-        "has_no_binary_artifacts"
+        "has_no_binary_artifacts",
     ]
 
     def __init__(self, context):
@@ -44,15 +46,24 @@ class OpenSSFScorecard(IndicatorPlugin):
         if cache_key in self._cache:
             return self._cache[cache_key]
 
-        url = url[:-4] if url.endswith(".git") else url
-        
-        check_values = ["CI-Tests", "SAST", "Maintained", "Fuzzing", "Dependency-Update-Tool", "Vulnerabilities", "Code-Review", "Packaging"]
+        url = url.removesuffix(".git")
+
+        check_values = [
+            "CI-Tests",
+            "SAST",
+            "Maintained",
+            "Fuzzing",
+            "Dependency-Update-Tool",
+            "Vulnerabilities",
+            "Code-Review",
+            "Packaging",
+        ]
         check_args = [arg for check in check_values for arg in ("--checks", check)]
 
         cmd = [
             "docker",
             "run",
-            "--rm", 
+            "--rm",
             "-e",
             f"GITHUB_AUTH_TOKEN={self.context.github_token}",
             f"gcr.io/openssf/scorecard:{self.version}",
@@ -179,7 +190,7 @@ class OpenSSFScorecard(IndicatorPlugin):
             evidence=evidence,
             success=success,
         )
-        
+
     def static_analysis_common_vulnerabilities(self, url, branch_hash_or_tag):
         results = self.execute(url, branch_hash_or_tag)
         check = self.get_score(results, "SAST")
@@ -199,9 +210,9 @@ class OpenSSFScorecard(IndicatorPlugin):
             evidence=evidence,
             success=success,
         )
-        
+
     def dependency_management(self, url, branch_hash_or_tag):
-        success=False
+        success = False
         results = self.execute(url, branch_hash_or_tag)
         check = self.get_score(results, "Dependency-Update-Tool")
         if check["score"] > 0:
@@ -220,9 +231,9 @@ class OpenSSFScorecard(IndicatorPlugin):
             evidence=evidence,
             success=success,
         )
-        
+
     def no_critical_vulnerability(self, url, branch_hash_or_tag):
-        success=False
+        success = False
         results = self.execute(url, branch_hash_or_tag)
         check = self.get_score(results, "Vulnerabilities")
         if check["score"] >= 7:
@@ -240,9 +251,9 @@ class OpenSSFScorecard(IndicatorPlugin):
             evidence=evidence,
             success=success,
         )
-        
+
     def uses_fuzzing(self, url, branch_hash_or_tag):
-        success=False
+        success = False
         results = self.execute(url, branch_hash_or_tag)
         check = self.get_score(results, "Fuzzing")
         if check["score"] > 0:
@@ -261,7 +272,7 @@ class OpenSSFScorecard(IndicatorPlugin):
             evidence=evidence,
             success=success,
         )
-        
+
     def has_no_binary_artifacts(self, url, branch_hash_or_tag):
         results = self.execute(url, branch_hash_or_tag)
         check = self.get_score(results, "Fuzzing")

--- a/src/resqui/plugins/rsfc.py
+++ b/src/resqui/plugins/rsfc.py
@@ -31,6 +31,20 @@ class RSFC(IndicatorPlugin):
         "has_contribution_guidelines",
         "software_is_containerized",
     ]
+    local_mode_unsupported_checks = {
+        "RSFC-01-1",
+        "RSFC-03-1",
+        "RSFC-03-2",
+        "RSFC-03-3",
+        "RSFC-03-4",
+        "RSFC-03-5",
+        "RSFC-04-1",
+        "RSFC-04-5",
+        "RSFC-07-2",
+        "RSFC-09-1",
+        "RSFC-14-1",
+        "RSFC-20-1",
+    }
 
     def __init__(self, context):
         self.context = context
@@ -55,21 +69,18 @@ class RSFC(IndicatorPlugin):
                     "-w",
                     container_workspace,
                 ]
-                assessment_fpath = os.path.join(
-                    workspace.local_path, "rsfc_output", assessment_filename
-                )
+                assessment_fpath = os.path.join(workspace.local_path, "rsfc_output", assessment_filename)
             else:
                 run_args = [
                     "--rm",
                     *workspace.docker_mount_args("/rsfc/rsfc_output"),
                 ]
-                assessment_fpath = os.path.join(
-                    workspace.local_path, assessment_filename
-                )
+                assessment_fpath = os.path.join(workspace.local_path, assessment_filename)
 
             if self.context.local_path is not None:
                 local_project_path = os.path.abspath(self.context.local_path)
                 project_container_path = "/rsfc_project"
+                # add the project path as a volume to mount
                 run_args += ["-v", f"{local_project_path}:{project_container_path}"]
                 command = ["--local", project_container_path]
             else:
@@ -102,264 +113,86 @@ class RSFC(IndicatorPlugin):
 
         return report
 
-    def persistent_and_unique_identifier(self, url, branch_hash_or_tag):
-        # Last version (do not erase)
-        """report = self.execute(url, branch_hash_or_tag)
-        checks = report["checks"]
-        check_list = []
+    def _skipped_check_result(self, check_id):
+        print(f"⚠️  RSFC local mode does not run {check_id}; skipping indicator")
+        return CheckResult(
+            process="RSFC local mode",
+            status_id="schema:FailedActionStatus",
+            output="missing",
+            evidence=(
+                f"RSFC local analysis does not generate check '{check_id}'. The indicator is skipped for local mode."
+            ),
+            success=False,
+        )
 
-        for check in checks:
-            if "persistent_and_unique_identifier" in check["assessesIndicator"]["@id"]:
-                if check["output"] == "true":
-                    success = True
-                else:
-                    success = False
+    def _check_result(self, report, check_id):
+        if self.context.local_path is not None and check_id in self.local_mode_unsupported_checks:
+            return self._skipped_check_result(check_id)
 
-                check_res = CheckResult(
-                    process=check["process"],
-                    status_id=check["status"]["@id"],
-                    output=check["output"],
-                    evidence=check["evidence"],
-                    success=success,
-                )
+        check = report.get(check_id)
+        if check is None:
+            raise KeyError(f"RSFC did not generate the expected check with id '{check_id}'")
 
-                check_list.append(check_res)
-
-        return check_list"""
-
-        report = self.execute(url, branch_hash_or_tag)
-        check = report["RSFC-01-1"]
-        if check["output"] == "true":
-            success = True
-        else:
-            success = False
-        check = CheckResult(
+        return CheckResult(
             process=check["process"],
             status_id=check["status"]["@id"],
             output=check["output"],
             evidence=check["evidence"],
-            success=success,
+            success=check["output"] == "true",
         )
 
-        return check
+    def persistent_and_unique_identifier(self, url, branch_hash_or_tag):
+        report = self.execute(url, branch_hash_or_tag)
+        return self._check_result(report, "RSFC-01-1")
 
     def software_has_documentation(self, url, branch_hash_or_tag):
         report = self.execute(url, branch_hash_or_tag)
-        check = report["RSFC-05-3"]
-        if check["output"] == "true":
-            success = True
-        else:
-            success = False
-        check = CheckResult(
-            process=check["process"],
-            status_id=check["status"]["@id"],
-            output=check["output"],
-            evidence=check["evidence"],
-            success=success,
-        )
-
-        return check
+        return self._check_result(report, "RSFC-05-3")
 
     def requirements_specified(self, url, branch_hash_or_tag):
         report = self.execute(url, branch_hash_or_tag)
-        check = report["RSFC-13-1"]
-        if check["output"] == "true":
-            success = True
-        else:
-            success = False
-        check = CheckResult(
-            process=check["process"],
-            status_id=check["status"]["@id"],
-            output=check["output"],
-            evidence=check["evidence"],
-            success=success,
-        )
-
-        return check
+        return self._check_result(report, "RSFC-13-1")
 
     def has_releases(self, url, branch_hash_or_tag):
         report = self.execute(url, branch_hash_or_tag)
-        check = report["RSFC-03-1"]
-        if check["output"] == "true":
-            success = True
-        else:
-            success = False
-        check = CheckResult(
-            process=check["process"],
-            status_id=check["status"]["@id"],
-            output=check["output"],
-            evidence=check["evidence"],
-            success=success,
-        )
-
-        return check
+        return self._check_result(report, "RSFC-03-1")
 
     def software_has_license(self, url, branch_hash_or_tag):
         report = self.execute(url, branch_hash_or_tag)
-        check = report["RSFC-15-1"]
-        if check["output"] == "true":
-            success = True
-        else:
-            success = False
-        check = CheckResult(
-            process=check["process"],
-            status_id=check["status"]["@id"],
-            output=check["output"],
-            evidence=check["evidence"],
-            success=success,
-        )
-
-        return check
+        return self._check_result(report, "RSFC-15-1")
 
     def descriptive_metadata(self, url, branch_hash_or_tag):
         report = self.execute(url, branch_hash_or_tag)
-        check = report["RSFC-04-4"]
-        if check["output"] == "true":
-            success = True
-        else:
-            success = False
-        check = CheckResult(
-            process=check["process"],
-            status_id=check["status"]["@id"],
-            output=check["output"],
-            evidence=check["evidence"],
-            success=success,
-        )
-
-        return check
+        return self._check_result(report, "RSFC-04-4")
 
     def versioning_standards_use(self, url, branch_hash_or_tag):
         report = self.execute(url, branch_hash_or_tag)
-        check = report["RSFC-03-6"]
-        if check["output"] == "true":
-            success = True
-        else:
-            success = False
-        check = CheckResult(
-            process=check["process"],
-            status_id=check["status"]["@id"],
-            output=check["output"],
-            evidence=check["evidence"],
-            success=success,
-        )
-
-        return check
+        return self._check_result(report, "RSFC-03-6")
 
     def version_control_use(self, url, branch_hash_or_tag):
         report = self.execute(url, branch_hash_or_tag)
-        check = report["RSFC-09-1"]
-        if check["output"] == "true":
-            success = True
-        else:
-            success = False
-        check = CheckResult(
-            process=check["process"],
-            status_id=check["status"]["@id"],
-            output=check["output"],
-            evidence=check["evidence"],
-            success=success,
-        )
-
-        return check
+        return self._check_result(report, "RSFC-09-1")
 
     def software_has_tests(self, url, branch_hash_or_tag):
         report = self.execute(url, branch_hash_or_tag)
-        check = report["RSFC-14-1"]
-        if check["output"] == "true":
-            success = True
-        else:
-            success = False
-        check = CheckResult(
-            process=check["process"],
-            status_id=check["status"]["@id"],
-            output=check["output"],
-            evidence=check["evidence"],
-            success=success,
-        )
-
-        return check
+        return self._check_result(report, "RSFC-14-1")
 
     def software_has_citation(self, url, branch_hash_or_tag):
         report = self.execute(url, branch_hash_or_tag)
-        check = report["RSFC-18-1"]
-        if check["output"] == "true":
-            success = True
-        else:
-            success = False
-        check = CheckResult(
-            process=check["process"],
-            status_id=check["status"]["@id"],
-            output=check["output"],
-            evidence=check["evidence"],
-            success=success,
-        )
-
-        return check
+        return self._check_result(report, "RSFC-18-1")
 
     def repository_workflows(self, url, branch_hash_or_tag):
         report = self.execute(url, branch_hash_or_tag)
-        check = report["RSFC-19-1"]
-        if check["output"] == "true":
-            success = True
-        else:
-            success = False
-        check = CheckResult(
-            process=check["process"],
-            status_id=check["status"]["@id"],
-            output=check["output"],
-            evidence=check["evidence"],
-            success=success,
-        )
-
-        return check
+        return self._check_result(report, "RSFC-19-1")
 
     def archived_in_software_heritage(self, url, branch_hash_or_tag):
         report = self.execute(url, branch_hash_or_tag)
-        check = report["RSFC-08-1"]
-        if check["output"] == "true":
-            success = True
-        else:
-            success = False
-        check = CheckResult(
-            process=check["process"],
-            status_id=check["status"]["@id"],
-            output=check["output"],
-            evidence=check["evidence"],
-            success=success,
-        )
-
-        return check
+        return self._check_result(report, "RSFC-08-1")
 
     def has_contribution_guidelines(self, url, branch_hash_or_tag):
         report = self.execute(url, branch_hash_or_tag)
-        check = report["RSFC-21-1"]
-        if check["output"] == "true":
-            success = True
-        else:
-            success = False
-        check = CheckResult(
-            process=check["process"],
-            status_id=check["status"]["@id"],
-            output=check["output"],
-            evidence=check["evidence"],
-            success=success,
-        )
-
-        return check
+        return self._check_result(report, "RSFC-21-1")
 
     def software_is_containerized(self, url, branch_hash_or_tag):
         report = self.execute(url, branch_hash_or_tag)
-        check = report["RSFC-22-1"]
-        if check["output"] == "true":
-            success = True
-        else:
-            success = False
-        check = CheckResult(
-            process=check["process"],
-            status_id=check["status"]["@id"],
-            output=check["output"],
-            evidence=check["evidence"],
-            success=success,
-        )
-
-        return check
+        return self._check_result(report, "RSFC-22-1")

--- a/src/resqui/plugins/rsfc.py
+++ b/src/resqui/plugins/rsfc.py
@@ -1,16 +1,19 @@
 import json
 import os
 
-from resqui.plugins.base import IndicatorPlugin
-from resqui.executors import DockerExecutor
 from resqui.core import CheckResult
+from resqui.executors import DockerExecutor
+from resqui.plugins.base import IndicatorPlugin
 from resqui.workspace import create_workspace
 
 
 class RSFC(IndicatorPlugin):
     name = "RSFC"
     id = "https://w3id.org/everse/tools/rsfc"
-    version = "0.1.7"
+    version = "0.1.8"
+    # The RSFC Docker CLI accepts local project directory analysis with --local,
+    # but the path must be inside a container-mounted volume.
+    supports_local_path = True
     image_url = f"docker.io/amonterodx/rsfc:{version}"
     indicators = [
         "persistent_and_unique_identifier",
@@ -26,7 +29,7 @@ class RSFC(IndicatorPlugin):
         "repository_workflows",
         "archived_in_software_heritage",
         "has_contribution_guidelines",
-        "software_is_containerized"
+        "software_is_containerized",
     ]
 
     def __init__(self, context):
@@ -42,7 +45,6 @@ class RSFC(IndicatorPlugin):
         url = url.removesuffix(".git")
 
         assessment_filename = "rsfc_assessment.json"
-
 
         with create_workspace(prefix="resqui-rsfc-") as workspace:
             if workspace.is_shared:
@@ -61,9 +63,17 @@ class RSFC(IndicatorPlugin):
                     "--rm",
                     *workspace.docker_mount_args("/rsfc/rsfc_output"),
                 ]
-                assessment_fpath = os.path.join(workspace.local_path, assessment_filename)
+                assessment_fpath = os.path.join(
+                    workspace.local_path, assessment_filename
+                )
 
-            command = ["--repo", url]
+            if self.context.local_path is not None:
+                local_project_path = os.path.abspath(self.context.local_path)
+                project_container_path = "/rsfc_project"
+                run_args += ["-v", f"{local_project_path}:{project_container_path}"]
+                command = ["--local", project_container_path]
+            else:
+                command = ["--repo", url]
             if self.context.github_token:
                 command += ["-t", self.context.github_token]
 
@@ -75,17 +85,17 @@ class RSFC(IndicatorPlugin):
 
             with open(assessment_fpath) as f:
                 report = json.load(f)
-                
+
         # New remapping for better management
         checks_by_id = {}
-        
+
         for check in report.get("checks", []):
             test_id_completo = check.get("test_id", "")
             test_id_corto = test_id_completo.split("/")[-1]
-            
+
             if test_id_corto:
                 checks_by_id[test_id_corto] = check
-                
+
         report = checks_by_id
 
         self._cache[cache_key] = report
@@ -93,9 +103,8 @@ class RSFC(IndicatorPlugin):
         return report
 
     def persistent_and_unique_identifier(self, url, branch_hash_or_tag):
-        
         # Last version (do not erase)
-        '''report = self.execute(url, branch_hash_or_tag)
+        """report = self.execute(url, branch_hash_or_tag)
         checks = report["checks"]
         check_list = []
 
@@ -116,8 +125,8 @@ class RSFC(IndicatorPlugin):
 
                 check_list.append(check_res)
 
-        return check_list'''
-        
+        return check_list"""
+
         report = self.execute(url, branch_hash_or_tag)
         check = report["RSFC-01-1"]
         if check["output"] == "true":
@@ -125,15 +134,14 @@ class RSFC(IndicatorPlugin):
         else:
             success = False
         check = CheckResult(
-                    process=check["process"],
-                    status_id=check["status"]["@id"],
-                    output=check["output"],
-                    evidence=check["evidence"],
-                    success=success,
-                )
-        
-        return check
+            process=check["process"],
+            status_id=check["status"]["@id"],
+            output=check["output"],
+            evidence=check["evidence"],
+            success=success,
+        )
 
+        return check
 
     def software_has_documentation(self, url, branch_hash_or_tag):
         report = self.execute(url, branch_hash_or_tag)
@@ -143,13 +151,13 @@ class RSFC(IndicatorPlugin):
         else:
             success = False
         check = CheckResult(
-                    process=check["process"],
-                    status_id=check["status"]["@id"],
-                    output=check["output"],
-                    evidence=check["evidence"],
-                    success=success,
-                )
-        
+            process=check["process"],
+            status_id=check["status"]["@id"],
+            output=check["output"],
+            evidence=check["evidence"],
+            success=success,
+        )
+
         return check
 
     def requirements_specified(self, url, branch_hash_or_tag):
@@ -160,13 +168,13 @@ class RSFC(IndicatorPlugin):
         else:
             success = False
         check = CheckResult(
-                    process=check["process"],
-                    status_id=check["status"]["@id"],
-                    output=check["output"],
-                    evidence=check["evidence"],
-                    success=success,
-                )
-        
+            process=check["process"],
+            status_id=check["status"]["@id"],
+            output=check["output"],
+            evidence=check["evidence"],
+            success=success,
+        )
+
         return check
 
     def has_releases(self, url, branch_hash_or_tag):
@@ -177,13 +185,13 @@ class RSFC(IndicatorPlugin):
         else:
             success = False
         check = CheckResult(
-                    process=check["process"],
-                    status_id=check["status"]["@id"],
-                    output=check["output"],
-                    evidence=check["evidence"],
-                    success=success,
-                )
-        
+            process=check["process"],
+            status_id=check["status"]["@id"],
+            output=check["output"],
+            evidence=check["evidence"],
+            success=success,
+        )
+
         return check
 
     def software_has_license(self, url, branch_hash_or_tag):
@@ -194,13 +202,13 @@ class RSFC(IndicatorPlugin):
         else:
             success = False
         check = CheckResult(
-                    process=check["process"],
-                    status_id=check["status"]["@id"],
-                    output=check["output"],
-                    evidence=check["evidence"],
-                    success=success,
-                )
-        
+            process=check["process"],
+            status_id=check["status"]["@id"],
+            output=check["output"],
+            evidence=check["evidence"],
+            success=success,
+        )
+
         return check
 
     def descriptive_metadata(self, url, branch_hash_or_tag):
@@ -211,13 +219,13 @@ class RSFC(IndicatorPlugin):
         else:
             success = False
         check = CheckResult(
-                    process=check["process"],
-                    status_id=check["status"]["@id"],
-                    output=check["output"],
-                    evidence=check["evidence"],
-                    success=success,
-                )
-        
+            process=check["process"],
+            status_id=check["status"]["@id"],
+            output=check["output"],
+            evidence=check["evidence"],
+            success=success,
+        )
+
         return check
 
     def versioning_standards_use(self, url, branch_hash_or_tag):
@@ -228,13 +236,13 @@ class RSFC(IndicatorPlugin):
         else:
             success = False
         check = CheckResult(
-                    process=check["process"],
-                    status_id=check["status"]["@id"],
-                    output=check["output"],
-                    evidence=check["evidence"],
-                    success=success,
-                )
-        
+            process=check["process"],
+            status_id=check["status"]["@id"],
+            output=check["output"],
+            evidence=check["evidence"],
+            success=success,
+        )
+
         return check
 
     def version_control_use(self, url, branch_hash_or_tag):
@@ -245,13 +253,13 @@ class RSFC(IndicatorPlugin):
         else:
             success = False
         check = CheckResult(
-                    process=check["process"],
-                    status_id=check["status"]["@id"],
-                    output=check["output"],
-                    evidence=check["evidence"],
-                    success=success,
-                )
-        
+            process=check["process"],
+            status_id=check["status"]["@id"],
+            output=check["output"],
+            evidence=check["evidence"],
+            success=success,
+        )
+
         return check
 
     def software_has_tests(self, url, branch_hash_or_tag):
@@ -262,13 +270,13 @@ class RSFC(IndicatorPlugin):
         else:
             success = False
         check = CheckResult(
-                    process=check["process"],
-                    status_id=check["status"]["@id"],
-                    output=check["output"],
-                    evidence=check["evidence"],
-                    success=success,
-                )
-        
+            process=check["process"],
+            status_id=check["status"]["@id"],
+            output=check["output"],
+            evidence=check["evidence"],
+            success=success,
+        )
+
         return check
 
     def software_has_citation(self, url, branch_hash_or_tag):
@@ -279,13 +287,13 @@ class RSFC(IndicatorPlugin):
         else:
             success = False
         check = CheckResult(
-                    process=check["process"],
-                    status_id=check["status"]["@id"],
-                    output=check["output"],
-                    evidence=check["evidence"],
-                    success=success,
-                )
-        
+            process=check["process"],
+            status_id=check["status"]["@id"],
+            output=check["output"],
+            evidence=check["evidence"],
+            success=success,
+        )
+
         return check
 
     def repository_workflows(self, url, branch_hash_or_tag):
@@ -296,13 +304,13 @@ class RSFC(IndicatorPlugin):
         else:
             success = False
         check = CheckResult(
-                    process=check["process"],
-                    status_id=check["status"]["@id"],
-                    output=check["output"],
-                    evidence=check["evidence"],
-                    success=success,
-                )
-        
+            process=check["process"],
+            status_id=check["status"]["@id"],
+            output=check["output"],
+            evidence=check["evidence"],
+            success=success,
+        )
+
         return check
 
     def archived_in_software_heritage(self, url, branch_hash_or_tag):
@@ -313,15 +321,15 @@ class RSFC(IndicatorPlugin):
         else:
             success = False
         check = CheckResult(
-                    process=check["process"],
-                    status_id=check["status"]["@id"],
-                    output=check["output"],
-                    evidence=check["evidence"],
-                    success=success,
-                )
-        
+            process=check["process"],
+            status_id=check["status"]["@id"],
+            output=check["output"],
+            evidence=check["evidence"],
+            success=success,
+        )
+
         return check
-    
+
     def has_contribution_guidelines(self, url, branch_hash_or_tag):
         report = self.execute(url, branch_hash_or_tag)
         check = report["RSFC-21-1"]
@@ -330,13 +338,13 @@ class RSFC(IndicatorPlugin):
         else:
             success = False
         check = CheckResult(
-                    process=check["process"],
-                    status_id=check["status"]["@id"],
-                    output=check["output"],
-                    evidence=check["evidence"],
-                    success=success,
-                )
-        
+            process=check["process"],
+            status_id=check["status"]["@id"],
+            output=check["output"],
+            evidence=check["evidence"],
+            success=success,
+        )
+
         return check
 
     def software_is_containerized(self, url, branch_hash_or_tag):
@@ -347,11 +355,11 @@ class RSFC(IndicatorPlugin):
         else:
             success = False
         check = CheckResult(
-                    process=check["process"],
-                    status_id=check["status"]["@id"],
-                    output=check["output"],
-                    evidence=check["evidence"],
-                    success=success,
-                )
-        
+            process=check["process"],
+            status_id=check["status"]["@id"],
+            output=check["output"],
+            evidence=check["evidence"],
+            success=success,
+        )
+
         return check

--- a/src/resqui/plugins/superlinter.py
+++ b/src/resqui/plugins/superlinter.py
@@ -1,9 +1,9 @@
 import platform
 import subprocess
 
-from resqui.plugins import IndicatorPlugin
-from resqui.executors import DockerExecutor
 from resqui.core import CheckResult
+from resqui.executors import DockerExecutor
+from resqui.plugins import IndicatorPlugin
 from resqui.workspace import create_workspace
 
 
@@ -12,6 +12,7 @@ class SuperLinter(IndicatorPlugin):
     version = "7.3.0"
     image_url = f"ghcr.io/super-linter/super-linter:v{version}"
     id = "https://w3id.org/everse/tools/superlinter"
+    supports_local_path = False
     indicators = ["has_no_linting_issues"]
 
     def __init__(self, context):
@@ -38,7 +39,7 @@ class SuperLinter(IndicatorPlugin):
             run_args = [
                 #            "-e",
                 #            "LOG_LEVEL=DEBUG",
-                "--rm",      
+                "--rm",
                 "-e",
                 "RUN_LOCAL=true",
                 "-e",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,17 +1,16 @@
 import contextlib
 import io
-import sys  # noqa: F401
 import os
 import subprocess
+import sys  # noqa: F401
 import tempfile
 import unittest
 from unittest.mock import MagicMock, patch
 
-from resqui.cli import GitInspector, Spinner, print_indicator_plugins, resqui
-from resqui.docopt import docopt
-
 # The module docstring is the docopt spec; import it for arg-parsing tests.
 import resqui.cli as cli_module
+from resqui.cli import GitInspector, Spinner, print_indicator_plugins, resqui
+from resqui.docopt import docopt
 
 
 def _make_git_repo(path):
@@ -181,8 +180,10 @@ class TestResquiExitPaths(unittest.TestCase):
             orig_dir = os.getcwd()
             os.chdir(plain_dir)
             try:
-                with patch("sys.argv", ["resqui"]), patch("builtins.print"), patch(
-                    "resqui.cli.Configuration"
+                with (
+                    patch("sys.argv", ["resqui"]),
+                    patch("builtins.print"),
+                    patch("resqui.cli.Configuration"),
                 ):
                     with self.assertRaises(SystemExit) as cm:
                         resqui()
@@ -191,9 +192,11 @@ class TestResquiExitPaths(unittest.TestCase):
                 os.chdir(orig_dir)
 
     def test_indicators_subcommand_exits_cleanly(self):
-        with patch("sys.argv", ["resqui", "indicators"]), patch(
-            "resqui.cli.print_indicator_plugins"
-        ), patch("builtins.print"):
+        with (
+            patch("sys.argv", ["resqui", "indicators"]),
+            patch("resqui.cli.print_indicator_plugins"),
+            patch("builtins.print"),
+        ):
             with self.assertRaises(SystemExit) as cm:
                 resqui()
             self.assertEqual(cm.exception.code, 0)
@@ -404,16 +407,18 @@ class TestResquiMainPath(unittest.TestCase):
     def test_clone_failure_propagates(self):
         import subprocess as sp
 
-        with self._patches(
-            argv=["resqui", "-u", "https://github.com/user/repo"],
-            **{
-                "resqui.cli.subprocess.run": MagicMock(
-                    side_effect=sp.CalledProcessError(128, "git")
-                )
-            },
+        with (
+            self._patches(
+                argv=["resqui", "-u", "https://github.com/user/repo"],
+                **{
+                    "resqui.cli.subprocess.run": MagicMock(
+                        side_effect=sp.CalledProcessError(128, "git")
+                    )
+                },
+            ),
+            self.assertRaises(sp.CalledProcessError),
         ):
-            with self.assertRaises(sp.CalledProcessError):
-                resqui()
+            resqui()
 
     def test_clone_zenodo_url_path(self):
         def mock_requests_get(url, headers=None):
@@ -455,6 +460,69 @@ class TestResquiMainPath(unittest.TestCase):
         ):
             resqui()
         self.summary.write.assert_called_once()
+
+    def test_local_project_path_mode_skips_incompatible_plugins(self):
+        mock_incompatible_class = MagicMock()
+        mock_incompatible_class.supports_local_path = False
+        mock_incompatible_class.name = "IncompatiblePlugin"
+        mock_incompatible_class.version = "0.1"
+        mock_incompatible_class.return_value = MagicMock()
+
+        mock_module = MagicMock()
+        mock_module.IncompatiblePlugin = mock_incompatible_class
+
+        self.config._cfg = {
+            "indicators": [
+                {
+                    "name": "dummy_indicator",
+                    "plugin": "IncompatiblePlugin",
+                    "@id": "https://example.com/dummy",
+                }
+            ]
+        }
+
+        with self._patches(
+            argv=["resqui", "-p", "."],
+            **{
+                "resqui.cli.importlib.import_module": MagicMock(
+                    return_value=mock_module
+                )
+            },
+        ):
+            resqui()
+
+        self.summary.add_indicator_result.assert_not_called()
+        self.summary.write.assert_called_once()
+
+    def test_local_project_path_mode_conflicts_with_url(self):
+        with self._patches(
+            argv=["resqui", "-p", ".", "-u", "https://github.com/user/repo"]
+        ):
+            with self.assertRaises(SystemExit) as cm:
+                resqui()
+            self.assertEqual(cm.exception.code, 1)
+
+    def test_local_project_path_mode_requires_directory(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            fake_file = os.path.join(temp_dir, "file.txt")
+            with open(fake_file, "w") as f:
+                f.write("data")
+            with self._patches(argv=["resqui", "-p", fake_file]):
+                with self.assertRaises(SystemExit) as cm:
+                    resqui()
+                self.assertEqual(cm.exception.code, 1)
+
+    def test_local_project_path_mode_expands_user_home_in_path(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            fake_path = os.path.join(temp_dir, "project")
+            os.makedirs(fake_path)
+            user_path = os.path.expanduser(os.path.join("~", os.path.relpath(fake_path, os.path.expanduser("~"))))
+
+            with self._patches(argv=["resqui", "-p", user_path]):
+                with patch("resqui.cli.os.path.isdir", return_value=True), patch("resqui.cli.os.path.abspath", return_value=fake_path):
+                    resqui()
+
+            self.summary.write.assert_called_once()
 
 
 class TestPrintIndicatorPluginsNoIndicators(unittest.TestCase):

--- a/tests/test_plugins_workspace.py
+++ b/tests/test_plugins_workspace.py
@@ -126,3 +126,34 @@ class TestPluginSharedWorkspace(unittest.TestCase):
 
         command, _ = fake_executor.calls[0]
         self.assertNotIn("-t", command)
+
+    def test_rsfc_supports_local_path_mode(self):
+        self.assertTrue(RSFC.supports_local_path)
+
+    def test_rsfc_mounts_local_project_path_when_local_path_mode(self):
+        def fake_rsfc_run(command, run_args=None):
+            run_args = run_args or []
+            self.assertIn("-v", run_args)
+            self.assertTrue(any(arg.endswith(":/rsfc_project") for arg in run_args))
+            workdir = run_args[run_args.index("-w") + 1] if "-w" in run_args else None
+            if workdir is not None:
+                output_dir = os.path.join(workdir, "rsfc_output")
+            else:
+                output_dir = os.path.join(root, "rsfc_output")
+            os.makedirs(output_dir, exist_ok=True)
+            assessment_path = os.path.join(output_dir, "rsfc_assessment.json")
+            with open(assessment_path, "w") as f:
+                json.dump({"checks": []}, f)
+            return SimpleNamespace(stdout="", stderr="")
+
+        fake_executor = FakeExecutor()
+        fake_executor.run = fake_rsfc_run
+
+        plugin = RSFC.__new__(RSFC)
+        plugin.context = Context(github_token="token", local_path="/tmp/project")
+        plugin.executor = fake_executor
+        plugin._cache = {}
+
+        with tempfile.TemporaryDirectory() as root:
+            with patch.dict(os.environ, self._env(root), clear=True):
+                plugin.execute("/tmp/project", "local")

--- a/tests/test_plugins_workspace.py
+++ b/tests/test_plugins_workspace.py
@@ -40,10 +40,9 @@ class TestPluginSharedWorkspace(unittest.TestCase):
         plugin.context = Context(github_token="token")
         plugin.executor = FakeExecutor(stderr="no leaks found")
 
-        with tempfile.TemporaryDirectory() as root:
-            with patch.dict(os.environ, self._env(root), clear=True):
-                with patch("resqui.plugins.gitleaks.subprocess.run", side_effect=fake_clone):
-                    plugin.has_no_security_leak("https://github.com/example/repo", "main")
+        with tempfile.TemporaryDirectory() as root, patch.dict(os.environ, self._env(root), clear=True):
+            with patch("resqui.plugins.gitleaks.subprocess.run", side_effect=fake_clone):
+                plugin.has_no_security_leak("https://github.com/example/repo", "main")
 
         command, run_args = plugin.executor.calls[0]
         self.assertEqual(run_args, ["--rm", "-v", f"sqoo_resqui_work:{root}"])
@@ -55,10 +54,9 @@ class TestPluginSharedWorkspace(unittest.TestCase):
         plugin.context = Context(github_token="token")
         plugin.executor = FakeExecutor(stdout="")
 
-        with tempfile.TemporaryDirectory() as root:
-            with patch.dict(os.environ, self._env(root), clear=True):
-                with patch("resqui.plugins.superlinter.subprocess.run"):
-                    plugin.has_no_linting_issues("https://github.com/example/repo", "main")
+        with tempfile.TemporaryDirectory() as root, patch.dict(os.environ, self._env(root), clear=True):
+            with patch("resqui.plugins.superlinter.subprocess.run"):
+                plugin.has_no_linting_issues("https://github.com/example/repo", "main")
 
         _, run_args = plugin.executor.calls[0]
         self.assertIn("--rm", run_args)
@@ -88,9 +86,8 @@ class TestPluginSharedWorkspace(unittest.TestCase):
         plugin.executor = fake_executor
         plugin._cache = {}
 
-        with tempfile.TemporaryDirectory() as root:
-            with patch.dict(os.environ, self._env(root), clear=True):
-                plugin.execute("https://github.com/example/repo", "main")
+        with tempfile.TemporaryDirectory() as root, patch.dict(os.environ, self._env(root), clear=True):
+            plugin.execute("https://github.com/example/repo", "main")
 
         command, run_args = fake_executor.calls[0]
         self.assertIn("-v", run_args)
@@ -120,9 +117,8 @@ class TestPluginSharedWorkspace(unittest.TestCase):
         plugin.executor = fake_executor
         plugin._cache = {}
 
-        with tempfile.TemporaryDirectory() as root:
-            with patch.dict(os.environ, self._env(root), clear=True):
-                plugin.execute("https://github.com/example/repo", "main")
+        with tempfile.TemporaryDirectory() as root, patch.dict(os.environ, self._env(root), clear=True):
+            plugin.execute("https://github.com/example/repo", "main")
 
         command, _ = fake_executor.calls[0]
         self.assertNotIn("-t", command)
@@ -154,6 +150,19 @@ class TestPluginSharedWorkspace(unittest.TestCase):
         plugin.executor = fake_executor
         plugin._cache = {}
 
-        with tempfile.TemporaryDirectory() as root:
-            with patch.dict(os.environ, self._env(root), clear=True):
-                plugin.execute("/tmp/project", "local")
+        with tempfile.TemporaryDirectory() as root, patch.dict(os.environ, self._env(root), clear=True):
+            plugin.execute("/tmp/project", "local")
+
+    def test_rsfc_skips_local_mode_unsupported_checks(self):
+        plugin = RSFC.__new__(RSFC)
+        plugin.context = Context(github_token="token", local_path="/tmp/project")
+        plugin.executor = FakeExecutor()
+        plugin._cache = {}
+        plugin.execute = lambda url, branch_hash_or_tag: {}
+
+        result = plugin.version_control_use("/tmp/project", "local")
+
+        self.assertEqual(result.status_id, "schema:FailedActionStatus")
+        self.assertEqual(result.output, "missing")
+        self.assertFalse(result)
+        self.assertIn("RSFC local analysis does not generate check 'RSFC-09-1'", result.evidence)


### PR DESCRIPTION
## Summary

I added the option to run resqui locally instead of using remote state. 
This is a key element to test archived repository such as records stored on Zenodo for example.

Currently, only RSFC plugin has been set up to properly run on local path instead of url. RSFC plugin was already handling this feature and I just made this explicit changing the core Plugin class with a `support_local_path` boolean attribute. 

By default, all plugins have this attribute set to False. You can provide a local path instead of url by changing the argument from `-u <repo_url>` to `-p <path_to_folder_to_analyse>`.

## Validation

- [x] I ran `make test` locally, or I cannot run it and explained why.
- [x] If I changed CLI behavior, configuration loading, or plugin results, I ran `resqui -c configurations/basic.json -t <token>` or explained why that was not possible.

## Review notes

- [x] This PR targets `main`.
- [x] I updated `README.md` if I changed CLI flags, action inputs, setup steps, output semantics, or the expected configuration format.
- [x] I added or updated tests in `tests/` when behavior changed.

## Related issue

Is was not possible to test a project at a given state without git history. In my scenario, I wanted to test project that have uploaded on Zenodo as records. These are usually linked to a github/gitlab platform but resolving the exact state between the record and the git history was not trivial. Also, Zenodo record does not requires giving the repository url and the tag of the release.

