### PR TITLE
handle continue after indicator plugin failure

### DIFF
--- a/src/resqui/cli.py
+++ b/src/resqui/cli.py
@@ -223,7 +223,7 @@ def resqui():
         try:
             with Spinner():
                 results = getattr(plugin_instance, plugin_method)(url, branch_hash_or_tag)
-        except Exception as e:
+        except (subprocess.CalledProcessError, FileNotFoundError, ValueError) as e:
             print(f"\033[91m✖\033[0m {type(e).__name__}: {e}")
             continue
 

--- a/src/resqui/cli.py
+++ b/src/resqui/cli.py
@@ -213,15 +213,19 @@ def resqui():
             with Spinner(print_time=False):
                 try:
                     plugin_instances[plugin_class_name] = plugin_class(context)
-                except (ExecutorInitError, PluginInitError) as e:
+                except (ExecutorInitError, PluginInitError, subprocess.CalledProcessError) as e:
                     print(f"⚠️  {e} (skipping its indicators)")
                     continue
 
         plugin_instance = plugin_instances[plugin_class_name]
         plugin_method = indicator["name"]
 
-        with Spinner():
-            results = getattr(plugin_instance, plugin_method)(url, branch_hash_or_tag)
+        try:
+            with Spinner():
+                results = getattr(plugin_instance, plugin_method)(url, branch_hash_or_tag)
+        except Exception as e:
+            print(f"\033[91m✖\033[0m {type(e).__name__}: {e}")
+            continue
 
         for result in ensure_list(results):
             status = "\033[92m✔\033[0m" if result else "\033[91m✖\033[0m"


### PR DESCRIPTION
## Summary

This change allows RESQUI to continue running the remaining indicators when a plugin fails during initialization or when an individual indicator execution raises an error.
It covers cases such as an OpenSSF Scorecard Docker image pull failure during plugin initialization, and runtime indicator failures such as OEBFAIR not generating the expected assessment file.

Requested by @dgarijo 