### PR TITLE
Fix/openssfscorecard

### DIFF
--- a/src/resqui/plugins/openssfscorecard.py
+++ b/src/resqui/plugins/openssfscorecard.py
@@ -298,7 +298,11 @@ class OpenSSFScorecard(IndicatorPlugin):
         evidence = self.format_details(check["details"])
 
         return CheckResult(
-            process="Checks whether the project uses a static analysis tool to detect code quality errors or common mistakes.",
+            process="Checks whether the project uses a static analysis tool"
+                    " to detect code quality errors or common mistakes."
+                    "A low Scorecard SAST score does not necessarily mean that the"
+                    "project does not use SAST, since Scorecard may not detect all possible SAST setups."
+                    "documentation: github.com/ossf/scorecard/blob/main/docs/checks.md#sast",
             status_id="schema:CompletedActionStatus",
             output=output,
             evidence=evidence,

--- a/src/resqui/plugins/openssfscorecard.py
+++ b/src/resqui/plugins/openssfscorecard.py
@@ -301,7 +301,7 @@ class OpenSSFScorecard(IndicatorPlugin):
             process=(
                 "Checks whether the project uses a static analysis tool "
                 "to detect code quality errors or common mistakes. "
-                "A low Scorecard SAST score does not necessarily mean that the "
+                "A low Scorecard Static Application Security Testing (SAST) score does not necessarily mean that the "
                 "project does not use SAST, since Scorecard may not detect all possible "
                 "SAST setups. "
                 "Documentation: https://github.com/ossf/scorecard/blob/main/docs/checks.md#sast"

--- a/src/resqui/plugins/openssfscorecard.py
+++ b/src/resqui/plugins/openssfscorecard.py
@@ -8,6 +8,7 @@ class OpenSSFScorecard(IndicatorPlugin):
     name = "OpenSSF Scorecard"
     id = "https://github.com/ossf/scorecard"
     version = "v5.4.0"
+    image_url = f"ghcr.io/ossf/scorecard:{version}"
     indicators = [
         "has_ci_tests",
         "human_code_review_requirement",
@@ -17,7 +18,8 @@ class OpenSSFScorecard(IndicatorPlugin):
         "no_critical_vulnerability",
         "static_analysis_common_vulnerabilities",
         "project_is_active",
-        "has_no_binary_artifacts"
+        "has_no_binary_artifacts",
+        "uses_tool_for_warnings_and_mistakes"
     ]
 
     def __init__(self, context):
@@ -30,7 +32,7 @@ class OpenSSFScorecard(IndicatorPlugin):
     def instantiate(self):
         try:
             subprocess.run(
-                ["docker", "pull", f"gcr.io/openssf/scorecard:{self.version}"],
+                ["docker", "pull", self.image_url],
                 check=True,
                 stdout=subprocess.DEVNULL,
                 stderr=subprocess.DEVNULL,
@@ -55,7 +57,7 @@ class OpenSSFScorecard(IndicatorPlugin):
             "--rm", 
             "-e",
             f"GITHUB_AUTH_TOKEN={self.context.github_token}",
-            f"gcr.io/openssf/scorecard:{self.version}",
+            self.image_url,
             *check_args,
             "--show-details",
             "--repo",
@@ -276,6 +278,27 @@ class OpenSSFScorecard(IndicatorPlugin):
 
         return CheckResult(
             process="Checks if the project contains binary artifacts",
+            status_id="schema:CompletedActionStatus",
+            output=output,
+            evidence=evidence,
+            success=success,
+        )
+        
+    def uses_tool_for_warnings_and_mistakes(self, url, branch_hash_or_tag):
+        results = self.execute(url, branch_hash_or_tag)
+        check = self.get_score(results, "SAST")
+
+        if check["score"] > 0:
+            output = "true"
+            success = True
+        else:
+            output = "false"
+            success = False
+
+        evidence = self.format_details(check["details"])
+
+        return CheckResult(
+            process="Checks whether the project uses a static analysis tool to detect code quality errors or common mistakes.",
             status_id="schema:CompletedActionStatus",
             output=output,
             evidence=evidence,

--- a/src/resqui/plugins/openssfscorecard.py
+++ b/src/resqui/plugins/openssfscorecard.py
@@ -298,11 +298,14 @@ class OpenSSFScorecard(IndicatorPlugin):
         evidence = self.format_details(check["details"])
 
         return CheckResult(
-            process="Checks whether the project uses a static analysis tool"
-                    " to detect code quality errors or common mistakes."
-                    "A low Scorecard SAST score does not necessarily mean that the"
-                    "project does not use SAST, since Scorecard may not detect all possible SAST setups."
-                    "documentation: github.com/ossf/scorecard/blob/main/docs/checks.md#sast",
+            process=(
+                "Checks whether the project uses a static analysis tool "
+                "to detect code quality errors or common mistakes. "
+                "A low Scorecard SAST score does not necessarily mean that the "
+                "project does not use SAST, since Scorecard may not detect all possible "
+                "SAST setups. "
+                "Documentation: https://github.com/ossf/scorecard/blob/main/docs/checks.md#sast"
+            ),
             status_id="schema:CompletedActionStatus",
             output=output,
             evidence=evidence,


### PR DESCRIPTION
- Updated the OpenSSF Scorecard Docker image to use `ghcr.io/ossf/scorecard:v5.4.0` via `image_url`, replacing the old `gcr.io/openssf/scorecard` image
- Added the `uses_tool_for_warnings_and_mistakes` indicator, based on the Scorecard `SAST` check (equivalents according to: https://github.com/EVERSE-ResearchSoftware/indicators/blob/main/website/utils/crosswalk.json)
- The new indicator returns `true` when the `SAST` score is greater than `0`, and uses the Scorecard details as evidence